### PR TITLE
Defaultratios

### DIFF
--- a/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
@@ -39,7 +39,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javax.xml.bind.JAXBException;
 import org.cirdles.squid.Squid;
-import static org.cirdles.squid.constants.Squid3Constants.DEFAULT_RATIOS_LIST_FOR_10_SPECIES;
+import static org.cirdles.squid.constants.Squid3Constants.DEFAULT_RATIOS_LIST_FOR_11_SPECIES;
 import org.cirdles.squid.core.CalamariReportsEngine;
 import static org.cirdles.squid.core.CalamariReportsEngine.CalamariReportFlavors.MEAN_RATIOS_PER_SPOT_UNKNOWNS;
 import org.cirdles.squid.dialogs.SquidMessageDialog;
@@ -758,7 +758,15 @@ public class SquidUIController implements Initializable {
 
     @FXML
     private void default10SpeciesRatioSetAction(ActionEvent event) {
-        squidProject.getTask().updateRatioNames(DEFAULT_RATIOS_LIST_FOR_10_SPECIES);
+    }
+    
+    @FXML
+    private void default11SpeciesRatioSetAction(ActionEvent event) {
+        List<String> default11Ratios = new ArrayList<>();
+        for(int i = 0; i < DEFAULT_RATIOS_LIST_FOR_11_SPECIES.length; i++){
+            default11Ratios.add(DEFAULT_RATIOS_LIST_FOR_11_SPECIES[i]);
+        }
+        squidProject.getTask().updateRatioNames(default11Ratios);
         launchRatiosManager();
     }
 

--- a/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -763,8 +764,8 @@ public class SquidUIController implements Initializable {
     @FXML
     private void default11SpeciesRatioSetAction(ActionEvent event) {
         List<String> default11Ratios = new ArrayList<>();
-        for(int i = 0; i < DEFAULT_RATIOS_LIST_FOR_11_SPECIES.length; i++){
-            default11Ratios.add(DEFAULT_RATIOS_LIST_FOR_11_SPECIES[i]);
+        for (String DEFAULT_RATIOS_LIST_FOR_11_SPECIES1 : DEFAULT_RATIOS_LIST_FOR_11_SPECIES) {
+            default11Ratios.add(DEFAULT_RATIOS_LIST_FOR_11_SPECIES1);
         }
         squidProject.getTask().updateRatioNames(default11Ratios);
         launchRatiosManager();

--- a/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="675.0" prefWidth="925.0" styleClass="backgroundCalamari" stylesheets="@css/projectManager.css" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.cirdles.squid.gui.SquidUIController">
+<VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="675.0" prefWidth="925.0" styleClass="backgroundCalamari" stylesheets="@css/projectManager.css" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.cirdles.squid.gui.SquidUIController">
   <children>
     <MenuBar VBox.vgrow="NEVER">
       <menus>
@@ -63,8 +63,8 @@
                     <items>
                       <MenuItem mnemonicParsing="false" onAction="#defaultEmptyRatioSetAction" text="Empty" />
                         <MenuItem disable="true" mnemonicParsing="false" text="9 Species" />
-                        <MenuItem mnemonicParsing="false" onAction="#default10SpeciesRatioSetAction" text="10 Species" />
-                        <MenuItem disable="true" mnemonicParsing="false" text="11 Species" />
+                        <MenuItem disable="true" mnemonicParsing="false" onAction="#default10SpeciesRatioSetAction" text="10 Species" />
+                        <MenuItem mnemonicParsing="false" onAction="#default11SpeciesRatioSetAction" text="11 Species" />
                     </items>
                   </Menu>
               </items>

--- a/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
+++ b/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
@@ -97,6 +97,10 @@ public final class Squid3Constants {
     public static final String URL_STRING_FOR_SQUIDTASK_EXPRESSION_XML_SCHEMA_LOCAL
             = "Schema/SquidTask_ExpressionXMLSchema.xsd";
 
+    /**
+     * Acts as default set of ratios when loading a default ratio set.
+     * Must be converted to List.
+     */
     public static final String[] DEFAULT_RATIOS_LIST_FOR_11_SPECIES = new String[]{
         "204/206", "207/206", "208/206", "238/196", "206/238", "254/238",
         "248/254", "206/270", "270/254", "206/254", "238/206"};

--- a/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
+++ b/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
@@ -97,15 +97,9 @@ public final class Squid3Constants {
     public static final String URL_STRING_FOR_SQUIDTASK_EXPRESSION_XML_SCHEMA_LOCAL
             = "Schema/SquidTask_ExpressionXMLSchema.xsd";
 
-    public static final List<String> DEFAULT_RATIOS_LIST_FOR_10_SPECIES = new ArrayList<>();
-    static{
-        String [] ratios = new String[]{
-                        "204/206", "207/206", "208/206", "238/196", "206/238", "254/238", "248/254", "206/270", "270/254", "206/254", "238/206"};
-        
-        for (int i = 0; i < ratios.length; i ++){
-            DEFAULT_RATIOS_LIST_FOR_10_SPECIES.add(ratios[i]);
-        }
-    }
+    public static final String[] DEFAULT_RATIOS_LIST_FOR_11_SPECIES = new String[]{
+        "204/206", "207/206", "208/206", "238/196", "206/238", "254/238",
+        "248/254", "206/270", "270/254", "206/254", "238/206"};
                     
 
 }

--- a/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
+++ b/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
@@ -15,6 +15,7 @@
  */
 package org.cirdles.squid.constants;
 
+
 /**
  *
  * @author bowring

--- a/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
+++ b/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
@@ -15,10 +15,6 @@
  */
 package org.cirdles.squid.constants;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 /**
  *
  * @author bowring

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/builtinTasks/Squid3ExampleTask1.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/builtinTasks/Squid3ExampleTask1.java
@@ -15,7 +15,9 @@
  */
 package org.cirdles.squid.tasks.builtinTasks;
 
-import static org.cirdles.squid.constants.Squid3Constants.DEFAULT_RATIOS_LIST_FOR_10_SPECIES;
+import java.util.ArrayList;
+import java.util.List;
+import static org.cirdles.squid.constants.Squid3Constants.DEFAULT_RATIOS_LIST_FOR_11_SPECIES;
 import org.cirdles.squid.tasks.Task;
 import org.cirdles.squid.tasks.expressions.Expression;
 import org.cirdles.squid.tasks.expressions.builtinExpressions.SquidExpressionMinus1;
@@ -47,8 +49,8 @@ public class Squid3ExampleTask1 extends Task {
         this.provenance = "Builtin task.";
         this.dateRevised = 0l;
 
-        this.ratioNames = DEFAULT_RATIOS_LIST_FOR_10_SPECIES;
-        
+        this.ratioNames = populateRatioNames();
+
         taskExpressionsOrdered.add(
                 new Expression(new CustomExpression_LnUO_U(), CustomExpression_LnUO_U.excelExpressionString));
         taskExpressionsOrdered.add(
@@ -63,5 +65,13 @@ public class Squid3ExampleTask1 extends Task {
         taskExpressionsOrdered.add(
                 new Expression(new SquidExpressionMinus3(), SquidExpressionMinus3.excelExpressionString));
         taskExpressionsOrdered.add(new Expression(new CustomExpression_Net204cts_sec(), CustomExpression_Net204cts_sec.excelExpressionString));
+    }
+
+    private List<String> populateRatioNames() {
+        List<String> default10Ratios = new ArrayList<>();
+        for (int i = 0; i < DEFAULT_RATIOS_LIST_FOR_11_SPECIES.length; i++) {
+            default10Ratios.add(DEFAULT_RATIOS_LIST_FOR_11_SPECIES[i]);
+        }
+        return default10Ratios;
     }
 }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/builtinTasks/Squid3ExampleTask1.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/builtinTasks/Squid3ExampleTask1.java
@@ -68,10 +68,10 @@ public class Squid3ExampleTask1 extends Task {
     }
 
     private List<String> populateRatioNames() {
-        List<String> default10Ratios = new ArrayList<>();
-        for (int i = 0; i < DEFAULT_RATIOS_LIST_FOR_11_SPECIES.length; i++) {
-            default10Ratios.add(DEFAULT_RATIOS_LIST_FOR_11_SPECIES[i]);
+        List<String> default11Ratios = new ArrayList<>();
+        for (String DEFAULT_RATIOS_LIST_FOR_11_SPECIES1 : DEFAULT_RATIOS_LIST_FOR_11_SPECIES) {
+            default11Ratios.add(DEFAULT_RATIOS_LIST_FOR_11_SPECIES1);
         }
-        return default10Ratios;
+        return default11Ratios;
     }
 }


### PR DESCRIPTION
Fixes #45. Also, the number of ratios initialized in SquidConstants was 11, not 10. The appropriate changes to reflect this were updated in both the GUI and code.