### PR TITLE
Improves whitespace handling.

### DIFF
--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionManagerController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionManagerController.java
@@ -771,7 +771,7 @@ public class ExpressionManagerController implements Initializable {
 
             currentExpression.setName(expressionNameTextField.getText().trim());
             currentExpression.setExpressionTree(expTree);
-            currentExpression.setExcelExpressionString(expressionExcelTextArea.getText().trim().replace("\n", ""));
+            currentExpression.setExcelExpressionString(expressionExcelTextArea.getText().trim());//.replace("\n", ""));
 
             squidProject.getTask().updateAffectedExpressions(currentExpression);
             squidProject.getTask().updateAllExpressions();

--- a/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
+++ b/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
@@ -67,13 +67,13 @@ expr:   FUNCTION '(' exprList+ ')'    // func call like f(), f(x), f(1,2) switch
     |   expr '<=' expr          // less than comparison (lowest priority op)
     |   expr '>' expr          // less than comparison (lowest priority op)
     |   expr '>=' expr          // less than comparison (lowest priority op)
+    |   WS expr
+    |   expr WS
     |   ARRAY_CALL
     |   NAMED_EXPRESSION
     |   ID                      // variable reference
-//    |   INT
     |   FLOAT
     |   INT
-    
     ;
 exprList : expr (',' expr)* ;   // arg list
 
@@ -141,7 +141,7 @@ fragment
 PARENS : '(' (LETTER | NUMBER | '.' | ' ')* ')';
 
 //LETTER : [a-zA-Z_%] ('-')? ;
-LETTER : [a-zA-Z_\t\n\r] ;
+LETTER : [a-zA-Z_] ;
 
 //NUMBER : [0-9_%]('.' [0-9])? ('-')? ;
 NUMBER : [0-9] ;
@@ -156,7 +156,8 @@ fragment
 Exponent : ('e'|'E') ('+'|'-')? ('0'..'9')+ ;
 
 
-WS  :   [ \t\n\r]+ -> skip ;
+//WS  :   [ \t\n\r]+ -> skip ;
+WS  :   (' ' | '\t' | '\n' | '\r') ;
 
 SL_COMMENT
     :   '//' .*? '\n' -> skip

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
@@ -148,15 +148,17 @@ public class ExpressionParser {
         while (parsedRPNreversedIterator.hasNext()) {
             String token = parsedRPNreversedIterator.next();
 
-            if (exp != null) {
-                // find next available empty left child
-                exp = walkUpTreeToEmptyLeftChild(exp);
-            }
+            if (TokenTypes.getType(token).compareTo(TokenTypes.FORMATTER) != 0) {
+                if (exp != null) {
+                    // find next available empty left child
+                    exp = walkUpTreeToEmptyLeftChild(exp);
+                }
 
-            exp = walkTree(token, exp);
-            if (firstPass) {
-                savedExp = exp;
-                firstPass = false;
+                exp = walkTree(token, exp);
+                if (firstPass) {
+                    savedExp = exp;
+                    firstPass = false;
+                }
             }
         }
 
@@ -207,8 +209,6 @@ public class ExpressionParser {
         ExpressionTreeInterface retExpTree = null;
 
         switch (tokenType) {
-            case FORMATTER:
-                break;
             case OPERATOR_A:
             case OPERATOR_M:
             case OPERATOR_E:
@@ -273,7 +273,7 @@ public class ExpressionParser {
                         && eqnSwitchNU) {
                     // this is the NU switch case for ratio where ratio is processed specially vs below where it is just looked up
                     retExpTree = retExpTreeKnown;
-                    
+
                 } else if (((ExpressionTree) retExpTreeKnown).hasRatiosOfInterest()
                         && (((ExpressionTree) retExpTreeKnown).getLeftET() instanceof ShrimpSpeciesNode)
                         && !eqnSwitchNU) {
@@ -283,15 +283,15 @@ public class ExpressionParser {
                             (ShrimpSpeciesNode) ((ExpressionTree) retExpTreeKnown).getLeftET(),
                             (ShrimpSpeciesNode) ((ExpressionTree) retExpTreeKnown).getRightET(),
                             uncertaintyDirective);
-                    
+
                 } else if ((retExpTreeKnown instanceof ShrimpSpeciesNode)
                         || (retExpTreeKnown instanceof SpotFieldNode)) {
                     retExpTree = retExpTreeKnown;
                     retExpTree.setUncertaintyDirective(uncertaintyDirective);
-                    
+
                 } else if (retExpTreeKnown.isSquidSwitchSCSummaryCalculation()) {
                     retExpTree = new VariableNodeForSummary(retExpTreeKnown.getName(), index, uncertaintyDirective);
-                    
+
                 } else {
                     retExpTree = new VariableNodeForPerSpotTaskExpressions(retExpTreeKnown.getName(), uncertaintyDirective, index);
                 }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ShuntingYard.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ShuntingYard.java
@@ -181,13 +181,6 @@ public class ShuntingYard {
                     lastWasOperationOrFunction = false;
                     break;
                 case NUMBER:
-//                    outputQueue.add(token);
-//                    if (!wereValues.empty()) {
-//                        wereValues.pop();
-//                        wereValues.push(true);
-//                    }
-//                    lastWasOperationOrFunction = false;
-//                    break;
                 case NAMED_CONSTANT:
                     outputQueue.add(token);
                     if (!wereValues.empty()) {
@@ -241,13 +234,6 @@ public class ShuntingYard {
                     lastWasOperationOrFunction = false;
                     break;
                 case FORMATTER:
-                    outputQueue.add(token);
-                    if (!wereValues.empty()) {
-                        wereValues.pop();
-                        wereValues.push(true);
-                    }
-                    lastWasOperationOrFunction = false;
-                    break;
                 case NAMED_EXPRESSION_INDEXED:
                 case NAMED_EXPRESSION:
                     outputQueue.add(token);
@@ -343,14 +329,14 @@ public class ShuntingYard {
                 retVal = RIGHT_PAREN;
             } else if (token.equals(",")) {
                 retVal = COMMA;
-            } else if ("|\t|\n|\r|".contains("|" + token + "|")) {
-                retVal = FORMATTER;
             } else if (FUNCTIONS_MAP.containsKey(token)) {
                 retVal = FUNCTION;
             } else if (token.matches("\\[(±?)(%?)\"(.*?)\"\\]\\[\\d\\]")) {
                 retVal = NAMED_EXPRESSION_INDEXED;
             } else if (token.matches("\\[(±?)(%?)\"(.*?)\"\\]")) {
                 retVal = NAMED_EXPRESSION;
+            } else if ("| |\t|\n|\r|".contains("|" + token + "|")) {
+                retVal = FORMATTER;
             } else if (isNumber(token)) {
                 retVal = NUMBER;
             }


### PR DESCRIPTION
Spaces, tabs, and newlines are tokenized so they can be represented in expression builder drag and drop editor. Each tab and newline will be ignored by parser.  Spaces between expressions will be ignored by parser.  Deletion of new lines (/n) is removed from ExpressionManagerController.