### PR TITLE
Expression handling refinements.

### DIFF
--- a/squidCore/src/main/java/org/cirdles/squid/tasks/Task.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/Task.java
@@ -448,66 +448,66 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
 
     private void reorderExpressions() {
         // cannot depend on comparator to do deep compares
-        for (Expression listedExp : taskExpressionsOrdered) {
-            // handle selectedisotope-specific expressions
-            // TODO: Better logic
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME) == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSTReferenceMaterialCalculation(true);
-            }
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME_S) == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME_S + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
-            }
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME + " %err") == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME + " %err" + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSTReferenceMaterialCalculation(true);
-            }
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME_S + " %err") == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME_S + " %err" + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
-            }
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_206_238_NAME) == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_206_238_NAME + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
-            }
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_206_238_NAME + " %err") == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_206_238_NAME + " %err" + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
-            }
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_208_232_NAME) == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_208_232_NAME + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
-            }
-            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_208_232_NAME + " %err") == 0)) {
-                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
-                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_208_232_NAME + " %err" + "\"]");
-                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
-                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
-            }
-        }
+//        for (Expression listedExp : taskExpressionsOrdered) {
+//            // handle selectedisotope-specific expressions
+//            // TODO: Better logic
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME) == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSTReferenceMaterialCalculation(true);
+//            }
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME_S) == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME_S + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+//            }
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME + " %err") == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME + " %err" + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSTReferenceMaterialCalculation(true);
+//            }
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TH_U_EQN_NAME_S + " %err") == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TH_U_EQN_NAME_S + " %err" + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+//            }
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_206_238_NAME) == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_206_238_NAME + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+//            }
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_206_238_NAME + " %err") == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_206_238_NAME + " %err" + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+//            }
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_208_232_NAME) == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_208_232_NAME + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+//            }
+//            if (directAltPD && (listedExp.getName().compareToIgnoreCase(SQUID_TOTAL_208_232_NAME + " %err") == 0)) {
+//                // TODO: using 1 * is a temporary hack to make expression work correctly in the case of defining one expression as another
+//                listedExp.setExcelExpressionString("1 * [\"" + selectedIndexIsotope.getIsotopeCorrectionPrefixString() + SQUID_TOTAL_208_232_NAME + " %err" + "\"]");
+//                listedExp.parseOriginalExpressionStringIntoExpressionTree(namedExpressionsMap);
+//                listedExp.getExpressionTree().setSquidSpecialUPbThExpression(true);
+//                listedExp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+//            }
+//        }
 
         try {
             Collections.sort(taskExpressionsOrdered);

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/Expression.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/Expression.java
@@ -50,8 +50,8 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
 
     private static final long serialVersionUID = 2614344042503810733L;
 
-    private String notes;
     private String name;
+    private String notes;
     private String excelExpressionString;
     private boolean squidSwitchNU;
     private ExpressionTreeInterface expressionTree;
@@ -70,12 +70,17 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
     }
 
     public Expression(ExpressionTreeInterface expressionTree, String excelExpressionString, boolean squidSwitchNU) {
+        this(expressionTree, excelExpressionString, squidSwitchNU, "");
+    }
+
+    public Expression(ExpressionTreeInterface expressionTree, String excelExpressionString, boolean squidSwitchNU, String notes) {
         this.name = expressionTree.getName();
         this.excelExpressionString = excelExpressionString;
         this.squidSwitchNU = squidSwitchNU;
         this.expressionTree = expressionTree;
         this.parsingStatusReport = "";
         this.argumentAudit = new ArrayList<>();
+        this.notes = notes;
     }
 
     @Override
@@ -94,7 +99,6 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
             retVal = true;
         } else if (obj instanceof Expression && (getExpressionTree() != null)) {
             // note checking if expressionTree is null due to bad parsing
-            //retVal = ((ExpressionTree) getExpressionTree()).equals((ExpressionTree) ((Expression) obj).getExpressionTree());
             retVal = (getName().compareToIgnoreCase(((Expression) obj).getName()) == 0);
         }
         return retVal;
@@ -230,7 +234,7 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
     }
 
     public String getNotes() {
-        if(notes==null){
+        if (notes == null) {
             notes = "";
         }
         return notes;
@@ -239,7 +243,7 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
     public void setNotes(String comments) {
         this.notes = comments;
     }
-    
+
     /**
      * @return the excelExpressionString
      */

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/builtinExpressions/BuiltInExpressionsFactory.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/builtinExpressions/BuiltInExpressionsFactory.java
@@ -68,16 +68,16 @@ public abstract class BuiltInExpressionsFactory {
     public static Map<String, ExpressionTreeInterface> generateParameters() {
         Map<String, ExpressionTreeInterface> parameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
-        ExpressionTreeInterface stdUPbRatio = new ConstantNode("StdUPbRatio", 0.0906025999827849);
+        ExpressionTreeInterface stdUPbRatio = new ConstantNode("StdUPbRatio", 0.0906025999827849); // Ref Mat Model
         parameters.put(stdUPbRatio.getName(), stdUPbRatio);
 
-        ExpressionTreeInterface stdPpmU = new ConstantNode("Std_ppmU", 903);
+        ExpressionTreeInterface stdPpmU = new ConstantNode("Std_ppmU", 903); // Ref Mat Model
         parameters.put(stdPpmU.getName(), stdPpmU);
 
-        ExpressionTreeInterface std_76 = new ConstantNode("Std_76", Squid3Constants.std_76);//    0.0587838486664528);
+        ExpressionTreeInterface std_76 = new ConstantNode("Std_76", Squid3Constants.std_76);//    0.0587838486664528); // Ref Mat Model
         parameters.put(std_76.getName(), std_76);
 
-        ExpressionTreeInterface stdThPbRatio = new ConstantNode("StdThPbRatio", 0.0280476031222372);
+        ExpressionTreeInterface stdThPbRatio = new ConstantNode("StdThPbRatio", 0.0280476031222372);// Ref Mat Model
         parameters.put(stdThPbRatio.getName(), stdThPbRatio);
 
         ExpressionTreeInterface stdRad86fact = new ConstantNode("StdRad86fact", Squid3Constants.stdRad86fact);//   0.309567309630921);
@@ -362,6 +362,10 @@ public abstract class BuiltInExpressionsFactory {
         Expression dummy = buildExpression("DUMMY", "5", true, true, false);
         dummy.getExpressionTree().setSquidSpecialUPbThExpression(false);
         experimentalExpressions.add(dummy);
+
+        Expression dummyS = buildExpression("DUMMYsum", "5", true, true, true);
+        dummyS.getExpressionTree().setSquidSpecialUPbThExpression(false);
+        experimentalExpressions.add(dummyS);
 
         return experimentalExpressions;
     }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/constants/ConstantNode.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/constants/ConstantNode.java
@@ -48,8 +48,8 @@ public class ConstantNode extends ExpressionTree {
      */
     public ConstantNode(String name, Object value) {
         this.name = name;
-        if (value instanceof Integer){
-            value = ((int)value) * 1.0;
+        if (value instanceof Integer) {
+            value = ((int) value) * 1.0;
         }
         this.value = value;
     }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/constants/ConstantNodeXMLConverter.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/constants/ConstantNodeXMLConverter.java
@@ -80,13 +80,13 @@ public class ConstantNodeXMLConverter implements Converter {
     @Override
     public void marshal(Object value, HierarchicalStreamWriter writer,
             MarshallingContext context) {
-        
+
         ExpressionTreeInterface constantNode = (ConstantNode) value;
-        
+
         writer.startNode("name");
         writer.setValue(constantNode.getName());
         writer.endNode();
-        
+
         writer.startNode("value");
         Object myValue = ((ConstantNode) constantNode).getValue();
         if (myValue instanceof Double) {
@@ -99,7 +99,7 @@ public class ConstantNodeXMLConverter implements Converter {
             writer.setValue(Boolean.toString((Boolean) ((ConstantNode) constantNode).getValue()));
         }
         writer.endNode();
-        
+
     }
 
     /**
@@ -118,13 +118,13 @@ public class ConstantNodeXMLConverter implements Converter {
     @Override
     public Object unmarshal(HierarchicalStreamReader reader,
             UnmarshallingContext context) {
-        
+
         ExpressionTreeInterface constantNode = new ConstantNode();
-        
+
         reader.moveDown();
         ((ConstantNode) constantNode).setName(reader.getValue());
         reader.moveUp();
-        
+
         reader.moveDown();
         String constant = reader.getValue();
         if (constant.contains("e")) { // boolean
@@ -139,12 +139,11 @@ public class ConstantNodeXMLConverter implements Converter {
                 // String
                 ((ConstantNode) constantNode).setValue(reader.getValue());
             }
-        
         }
-        
+
         reader.moveUp();
-        
+
         return constantNode;
     }
-    
+
 }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/expressionTrees/ExpressionTreeInterface.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/expressionTrees/ExpressionTreeInterface.java
@@ -167,7 +167,7 @@ public interface ExpressionTreeInterface {
      */
     public static double[] convertObjectArrayToDoubles(Object[] objects) throws SquidException {
         if (objects == null) {
-            throw new SquidException("Failed to retrieve data at convertObjectArrayToDOubles.");
+            throw new SquidException("Failed to retrieve data at convertObjectArrayToDoubles.");
         }
         double[] retVal = new double[objects.length];
         for (int i = 0; i < objects.length; i++) {

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/expressionTrees/ExpressionTreeXMLConverter.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/expressionTrees/ExpressionTreeXMLConverter.java
@@ -91,22 +91,22 @@ public class ExpressionTreeXMLConverter implements Converter {
     public void marshal(Object value, HierarchicalStreamWriter writer,
             MarshallingContext context) {
 
-        ExpressionTree expressionTree = (ExpressionTree) value;
+        ExpressionTreeInterface expressionTree = (ExpressionTree) value;
 
         writer.startNode("name");
         writer.setValue(expressionTree.getName());
         writer.endNode();
 
         writer.startNode("childrenET");
-        context.convertAnother(expressionTree.getChildrenET());
+        context.convertAnother(((ExpressionTree) expressionTree).getChildrenET());
         writer.endNode();
 
         writer.startNode("operation");
-        context.convertAnother(expressionTree.getOperation());
+        context.convertAnother(((ExpressionTree) expressionTree).getOperation());
         writer.endNode();
 
         writer.startNode("ratiosOfInterest");
-        context.convertAnother(expressionTree.getRatiosOfInterest());
+        context.convertAnother(((ExpressionTree) expressionTree).getRatiosOfInterest());
         writer.endNode();
 
         writer.startNode("squidSwitchSCSummaryCalculation");
@@ -128,17 +128,17 @@ public class ExpressionTreeXMLConverter implements Converter {
         writer.startNode("rootExpressionTree");
         writer.setValue(String.valueOf(expressionTree.isRootExpressionTree()));
         writer.endNode();
-        
+
         writer.startNode("squidSwitchConcentrationReferenceMaterialCalculation");
         writer.setValue(String.valueOf(expressionTree.isSquidSwitchConcentrationReferenceMaterialCalculation()));
         writer.endNode();
-        
+
         writer.startNode("uncertaintyDirective");
-        writer.setValue(expressionTree.getUncertaintyDirective());
+        writer.setValue(((ExpressionTree) expressionTree).getUncertaintyDirective());
         writer.endNode();
-        
+
         writer.startNode("index");
-        writer.setValue(Integer.toString(expressionTree.getIndex()));
+        writer.setValue(Integer.toString(((ExpressionTree) expressionTree).getIndex()));
         writer.endNode();
     }
 
@@ -158,8 +158,8 @@ public class ExpressionTreeXMLConverter implements Converter {
     @Override
     public Object unmarshal(HierarchicalStreamReader reader,
             UnmarshallingContext context) {
-////TODO CONFIRM FIELDS
-        ExpressionTree expressionTree = new ExpressionTree();
+
+        ExpressionTreeInterface expressionTree = new ExpressionTree();
 
         reader.moveDown();
         expressionTree.setName(reader.getValue());
@@ -205,7 +205,7 @@ public class ExpressionTreeXMLConverter implements Converter {
             childrenET.add(childExpressionTree);
             reader.moveUp();
         }
-        expressionTree.setChildrenET(childrenET);
+        ((ExpressionTree) expressionTree).setChildrenET(childrenET);
         reader.moveUp();
 
         // operation
@@ -213,12 +213,13 @@ public class ExpressionTreeXMLConverter implements Converter {
         reader.moveDown();
         OperationOrFunctionInterface operation = Operation.operationFactory(reader.getValue());
         if (operation == null) {
+            // try function list
             operation = Function.operationFactory(reader.getValue());
         }
         if (operation ==null){
             System.out.println("NULL OP  "+ expressionTree.getName() + "    " + reader.getValue());
         }
-        expressionTree.setOperation(operation);
+        ((ExpressionTree) expressionTree).setOperation(operation);
         reader.moveUp();
         reader.moveUp();
 
@@ -230,7 +231,7 @@ public class ExpressionTreeXMLConverter implements Converter {
             ratiosOfInterest.add(reader.getValue());
             reader.moveUp();
         }
-        expressionTree.setRatiosOfInterest(ratiosOfInterest);
+        ((ExpressionTree) expressionTree).setRatiosOfInterest(ratiosOfInterest);
         reader.moveUp();
 
         reader.moveDown();
@@ -256,15 +257,15 @@ public class ExpressionTreeXMLConverter implements Converter {
         reader.moveDown();
         expressionTree.setSquidSwitchConcentrationReferenceMaterialCalculation(Boolean.parseBoolean(reader.getValue()));
         reader.moveUp();
-        
+
         reader.moveDown();
         expressionTree.setUncertaintyDirective(reader.getValue());
         reader.moveUp();
-        
+
         reader.moveDown();
         expressionTree.setIndex(Integer.parseInt(reader.getValue()));
         reader.moveUp();
-        
+
         return expressionTree;
     }
 

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
@@ -347,6 +347,7 @@ public abstract class Function
     /**
      * @return the name
      */
+    @Override
     public String getName() {
         return name;
     }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/operations/Operation.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/operations/Operation.java
@@ -107,7 +107,7 @@ public abstract class Operation
         OPERATIONS_MAP.put("<=", lessThanEqual().getName());
         OPERATIONS_MAP.put(">", greaterThan().getName());
         OPERATIONS_MAP.put(">=", greaterThanEqual().getName());
-        //OPERATIONS_MAP.put("( EXPR )", pExp().getName());
+        OPERATIONS_MAP.put("$$", value().getName());
     }
 
     /**
@@ -156,6 +156,14 @@ public abstract class Operation
      */
     public static OperationOrFunctionInterface pExp() {
         return new Pexp();
+    }
+
+    /**
+     *
+     * @return
+     */
+    public static OperationOrFunctionInterface value() {
+        return new Value();
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/operations/Value.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/operations/Value.java
@@ -1,0 +1,78 @@
+/* 
+ * Copyright 2016 James F. Bowring and CIRDLES.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.squid.tasks.expressions.operations;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import java.util.List;
+import org.cirdles.squid.shrimp.ShrimpFractionExpressionInterface;
+import org.cirdles.squid.tasks.TaskInterface;
+import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeInterface;
+
+/**
+ *
+ * @author James F. Bowring
+ */
+@XStreamAlias("Operation")
+public class Value extends Operation {
+
+    /**
+     *
+     */
+    public Value() {
+        name = "value";
+        argumentCount = 1;
+        precedence = 4;
+        rowCount = 1;
+        colCount = 1;
+        labelsForOutputValues = new String[][]{{"Value"}};
+    }
+
+    /**
+     * Returns childrenET(0) - no changes
+     * @param childrenET the value of childrenET
+     * @param shrimpFractions the value of shrimpFraction
+     * @param task
+     * @return the double[][]
+     */
+    @Override
+    public Object[][] eval(
+            List<ExpressionTreeInterface> childrenET, List<ShrimpFractionExpressionInterface> shrimpFractions, TaskInterface task) {
+
+        Object[][] retVal;
+        try {
+            retVal = childrenET.get(0).eval(shrimpFractions, task);
+        } catch (Exception e) {
+            retVal = new Object[][]{{0.0}};
+        }
+        return retVal;
+    }
+
+    /**
+     *
+     * @param childrenET the value of childrenET
+     * @return
+     */
+    @Override
+    public String toStringMathML(List<ExpressionTreeInterface> childrenET) {
+        String retVal
+                = "<mrow>\n"
+                + toStringAnotherExpression(childrenET.get(0))
+                + "</mrow>\n";
+
+        return retVal;
+    }
+
+}

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
@@ -208,6 +208,17 @@ public class ExpressionParser {
 
         ExpressionTreeInterface retExpTree = null;
 
+        // check NAMED_CONSTANT choice to see if this is really a shortcut to an expression such as 
+        // Hfsens = ["Hfsens"]
+        if (tokenType.compareTo(tokenType.NAMED_CONSTANT) == 0) {
+            ExpressionTreeInterface retExpTreeTest = namedExpressionsMap.get(token);
+            if (retExpTreeTest != null) {
+                if (retExpTreeTest instanceof ExpressionTreeParsedFromExcelString) {
+                    tokenType = TokenTypes.NAMED_EXPRESSION;
+                }
+            }
+        }
+
         switch (tokenType) {
             case OPERATOR_A:
             case OPERATOR_M:

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
@@ -117,6 +117,11 @@ public class ExpressionParser {
 
             Collections.reverse(parsedRPN);
 
+            // detect if top-level singleton and if so, wrap in expression with hidden Value operation, '$$'
+            if (parsedRPN.size() == 1) {
+                parsedRPN.add(0, "$$");
+            }
+
             returnExpressionTree = buildTree(parsedRPN);
 
             // if single objects are the actual expression, don't change
@@ -129,6 +134,7 @@ public class ExpressionParser {
                 returnExpressionTree.setName(expression.getName());
 
             }
+
             // be sure top level expression is root
             returnExpressionTree.setRootExpressionTree(!(((ExpressionTree) returnExpressionTree).getLeftET() instanceof ShrimpSpeciesNode));
 
@@ -208,17 +214,6 @@ public class ExpressionParser {
 
         ExpressionTreeInterface retExpTree = null;
 
-        // check NAMED_CONSTANT choice to see if this is really a shortcut to an expression such as 
-        // Hfsens = ["Hfsens"]
-        if (tokenType.compareTo(tokenType.NAMED_CONSTANT) == 0) {
-            ExpressionTreeInterface retExpTreeTest = namedExpressionsMap.get(token);
-            if (retExpTreeTest != null) {
-                if (retExpTreeTest instanceof ExpressionTreeParsedFromExcelString) {
-                    tokenType = TokenTypes.NAMED_EXPRESSION;
-                }
-            }
-        }
-
         switch (tokenType) {
             case OPERATOR_A:
             case OPERATOR_M:
@@ -279,6 +274,8 @@ public class ExpressionParser {
                             }
                         }
                     }
+                } else if (retExpTreeKnown  instanceof ConstantNode){
+                    retExpTree = retExpTreeKnown;
                 } else if (((ExpressionTree) retExpTreeKnown).hasRatiosOfInterest()
                         && (((ExpressionTree) retExpTreeKnown).getLeftET() instanceof ShrimpSpeciesNode)
                         && eqnSwitchNU) {

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ShuntingYard.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ShuntingYard.java
@@ -303,7 +303,7 @@ public class ShuntingYard {
         /**
          *
          */
-        COMMA, 
+        COMMA,
         FORMATTER;
 
         private TokenTypes() {
@@ -321,7 +321,8 @@ public class ShuntingYard {
                 retVal = OPERATOR_A;
             } else if ("*/".contains(token)) {
                 retVal = OPERATOR_M;
-            } else if ("^".contains(token)) {
+            } else if ("|^|$$|".contains("|" + token + "|")) {
+                // '$$' is hidden Value operation for top level singleton expressions
                 retVal = OPERATOR_E;
             } else if ("(".contains(token)) {
                 retVal = LEFT_PAREN;
@@ -333,7 +334,11 @@ public class ShuntingYard {
                 retVal = FUNCTION;
             } else if (token.matches("\\[(±?)(%?)\"(.*?)\"\\]\\[\\d\\]")) {
                 retVal = NAMED_EXPRESSION_INDEXED;
+            } else if (token.matches("\\w+\\[\\d\\]") && !token.matches("\\d+\\[\\d\\]") && !token.toUpperCase().matches("TRUE\\[\\d\\]") && !token.toUpperCase().matches("FALSE\\[\\d\\]")) {
+                retVal = NAMED_EXPRESSION_INDEXED;
             } else if (token.matches("\\[(±?)(%?)\"(.*?)\"\\]")) {
+                retVal = NAMED_EXPRESSION;
+            } else if (token.matches("\\w+") && !token.matches("\\d+") && !token.toUpperCase().matches("TRUE") && !token.toUpperCase().matches("FALSE")) {
                 retVal = NAMED_EXPRESSION;
             } else if ("| |\t|\n|\r|".contains("|" + token + "|")) {
                 retVal = FORMATTER;

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/variables/VariableNodeForIsotopicRatios.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/variables/VariableNodeForIsotopicRatios.java
@@ -63,7 +63,7 @@ public class VariableNodeForIsotopicRatios extends VariableNodeForSummary {
         this.denominator = denominator;
         this.uncertaintyDirective = uncertaintyDirective;
         this.index = 0;
-        if (uncertaintyDirective.length() > 0){
+        if (uncertaintyDirective.length() > 0) {
             this.index = 1;
         }
     }
@@ -105,9 +105,6 @@ public class VariableNodeForIsotopicRatios extends VariableNodeForSummary {
     public Object[][] eval(List<ShrimpFractionExpressionInterface> shrimpFractions, TaskInterface task) throws SquidException {
         Object[][] retVal = new Object[shrimpFractions.size()][];
 
-        if (name.compareTo("208/248") == 0){
-            System.out.println("BINGO");
-        }
         try {
             Method method = ShrimpFractionExpressionInterface.class.getMethod(//
                     LOOKUP_METHODNAME_FOR_SHRIMPFRACTION,

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/variables/VariableNodeForSummary.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/variables/VariableNodeForSummary.java
@@ -23,7 +23,6 @@ import org.cirdles.squid.shrimp.ShrimpFractionExpressionInterface;
 import org.cirdles.squid.tasks.expressions.spots.SpotSummaryDetails;
 import org.cirdles.squid.tasks.TaskInterface;
 import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTree;
-import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeInterface;
 import static org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeInterface.convertArrayToObjects;
 
 /**
@@ -57,7 +56,7 @@ public class VariableNodeForSummary extends ExpressionTree {
         this.name = name;
         this.index = index;
         this.uncertaintyDirective = uncertaintyDirective;
-        if (uncertaintyDirective.length() > 0){
+        if (uncertaintyDirective.length() > 0) {
             this.index = 1;
         }
     }
@@ -76,11 +75,6 @@ public class VariableNodeForSummary extends ExpressionTree {
     public boolean isValid() {
         return (name.length() > 0);
     }
-
-//    @Override
-//    public boolean usesAnotherExpression(ExpressionTreeInterface exp) {
-//        return false;
-//    }
 
     @Override
     public boolean usesOtherExpression() {
@@ -114,11 +108,11 @@ public class VariableNodeForSummary extends ExpressionTree {
         Map<String, SpotSummaryDetails> detailsMap = task.getTaskExpressionsEvaluationsPerSpotSet();
         SpotSummaryDetails detail = detailsMap.get(name);
         double[][] valuesAll = detail.getValues().clone();
-        
+
         if (uncertaintyDirective.compareTo("%") == 0) {
             // index should be 1 from constructor
             valuesAll[0][1] = valuesAll[0][1] / valuesAll[0][0] * 100;
-        } 
+        }
 
         double[][] values = valuesAll.clone();
 
@@ -129,7 +123,7 @@ public class VariableNodeForSummary extends ExpressionTree {
                 values[0][i - index] = valuesAll[0][i];
             }
         }
-        
+
         Object[][] retVal = convertArrayToObjects(values);
 
         return retVal;

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/squidTask25/TaskSquid25.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/squidTask25/TaskSquid25.java
@@ -108,7 +108,7 @@ public class TaskSquid25 implements Serializable {
 
                 String[] parentNuclideStrings = lines[firstRow + 20].split("\t");
                 taskSquid25.parentNuclide = parentNuclideStrings[1];
-                
+
                 String[] directAltPDStrings = lines[firstRow + 21].split("\t");
                 taskSquid25.directAltPD = Boolean.valueOf(directAltPDStrings[1]);
 
@@ -123,7 +123,7 @@ public class TaskSquid25 implements Serializable {
 
                     if (taskSquid25.parentNuclide.contains("232")) {
                         primaryUThEqnName = SQUID_PRIMARY_UTH_EQN_NAME_TH;
-                        primaryUThPbEqn[1] = "1 * " + primaryUThPbEqn[1];
+                        primaryUThPbEqn[1] = primaryUThPbEqn[1];
                         primaryUThEqnOtherName = SQUID_PRIMARY_UTH_EQN_NAME_U;
                     }
 
@@ -141,7 +141,7 @@ public class TaskSquid25 implements Serializable {
                 if (secondaryUThPbEqn.length > 1) {
                     // this is the case of DirectAltPd = TRUE
                     taskSquid25.task25Equations.add(new TaskSquid25Equation(
-                            prepareSquid25ExcelEquationStringForSquid3("1 * " + secondaryUThPbEqn[1]),
+                            prepareSquid25ExcelEquationStringForSquid3(secondaryUThPbEqn[1]),
                             primaryUThEqnOtherName,
                             true,
                             true,
@@ -160,7 +160,7 @@ public class TaskSquid25 implements Serializable {
                             false,
                             true,
                             true, false));
-                } 
+                }
                 // this logic is moved to Ludwig Q3 in BuiltInExpressionsFactory
 //                else {
 //                    taskSquid25.task25Equations.add(new TaskSquid25Equation(


### PR DESCRIPTION
Implements improvements to expression handling that:
1. Provide for the use of simple expression names (only letters and numbers) such as "Expo" in other expressions without the use of brackets, as in ["Expo"].  In addition Expo11 is equivalent to ["Expo11"] and both are equivalent to Expo[0] and ["Expo"][0], providing a translation from the Squid2.5 syntax to Squid3 syntax.
2. Provide for a special hidden operation "Value" - denoted internally as "$$" - to support assignment of an expression to another by name.  Thus the expression for ["Expo_used"] could be the expression "Expo", where Expo itself is a more complicated expression.  This feature existed previously, but the XML serialization did not support it because a full expressionTree was not used for assignment and a workaround of "1 * expression" was needed to force creation of an expressionTree.  XML serialization now works for assignment.
3. Refactors Expression.java and various operations.
