### PR TITLE
Fixes bug in Function retrieval using reflection that was case-sensitive.

### DIFF
--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
@@ -297,8 +297,9 @@ public abstract class Function
      * @param operationName
      * @return
      */
-    public static OperationOrFunctionInterface operationFactory(String operationName) {
+    public static OperationOrFunctionInterface operationFactory(String myOperationName) {
         Function retVal = null;
+        String operationName = FUNCTIONS_MAP.get(myOperationName);
         Method method;
         if (operationName != null) {
             try {


### PR DESCRIPTION
@ryanbarrett1515 - this solves the serialization issue, however, you will still need your TaskXMLConverterTest to first remove unhealthy expressions from a task.