### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -968,7 +968,7 @@ public class ExpressionBuilderController implements Initializable {
         expressionAsTextArea.textProperty().bindBidirectional(expressionString);
         expressionString.addListener((observable, oldValue, newValue) -> {
             if (newValue != null) {
-                expressionIsSaved.set(false);
+                refreshSaved();
                 if (!makeStringFromTextFlow().equals(newValue)) {
                     makeTextFlowFromString(newValue);
                 }
@@ -985,7 +985,7 @@ public class ExpressionBuilderController implements Initializable {
 
         expressionNameTextField.textProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue != null) {
-                expressionIsSaved.set(false);
+                refreshSaved();
             }
         });
 
@@ -1168,7 +1168,7 @@ public class ExpressionBuilderController implements Initializable {
             selectedExpression.set(null);
             selectedExpression.set(new Expression("new_custom_expression", ""));
             currentMode.set(Mode.CREATE);
-            expressionIsSaved.set(false);
+            refreshSaved();
         }
     }
 
@@ -1180,7 +1180,7 @@ public class ExpressionBuilderController implements Initializable {
             exp.setName("copy of " + exp.getName());
             selectedExpression.set(exp);
             currentMode.set(Mode.CREATE);
-            expressionIsSaved.set(false);
+            refreshSaved();
             expressionIsCopied = true;
         }
     }
@@ -1189,7 +1189,7 @@ public class ExpressionBuilderController implements Initializable {
     private void editCustomExpressionAction(ActionEvent event) {
         if (selectedExpressionIsEditable.get() && currentMode.get().equals(Mode.VIEW)) {
             currentMode.set(Mode.EDIT);
-            expressionIsSaved.set(true);
+            refreshSaved();
         }
     }
 
@@ -1207,8 +1207,8 @@ public class ExpressionBuilderController implements Initializable {
             Expression exp = selectedExpression.get();
             selectedExpression.set(null);
             selectedExpression.set(exp);
-            selectedExpressionIsEditable.set(true);
             selectInAllPanes(exp, true);
+            selectedExpressionIsEditable.set(true);
         }
     }
 
@@ -1350,37 +1350,37 @@ public class ExpressionBuilderController implements Initializable {
     @FXML
     private void referenceMaterialCheckBoxAction(ActionEvent event) {
         concRefMatSwitchCheckBox.setSelected(false);
-        expressionIsSaved.set(false);
+        refreshSaved();
     }
 
     @FXML
     private void unknownSamplesCheckBoxAction(ActionEvent event) {
         concRefMatSwitchCheckBox.setSelected(false);
-        expressionIsSaved.set(false);
+        refreshSaved();
     }
 
     @FXML
     private void concRefMatCheckBoxAction(ActionEvent event) {
         unknownsSwitchCheckBox.setSelected(false);
         refMatSwitchCheckBox.setSelected(false);
-        expressionIsSaved.set(false);
+        refreshSaved();
     }
 
     @FXML
     private void summaryCalculationCheckBoxAction(ActionEvent event) {
         NUSwitchCheckBox.setSelected(false);
-        expressionIsSaved.set(false);
+        refreshSaved();
     }
 
     @FXML
     private void specialUPbThCheckBoxAction(ActionEvent event) {
-        expressionIsSaved.set(false);
+        refreshSaved();
     }
 
     @FXML
     private void NUSwitchCheckBoxAction(ActionEvent event) {
         summaryCalculationSwitchCheckBox.setSelected(false);
-        expressionIsSaved.set(false);
+        refreshSaved();
     }
 
     @FXML
@@ -2422,13 +2422,46 @@ public class ExpressionBuilderController implements Initializable {
         currentMode.set(Mode.VIEW);
         selectedExpression.set(null);
         selectedExpression.set(exp);
-        expressionIsSaved.set(true);
+        refreshSaved();
         //Calculate peeks
         populatePeeks(exp);
 
         selectInAllPanes(exp, true);
 
         selectedBeforeCreateOrCopy = null;
+    }
+
+    public void refreshSaved() {
+        boolean saved = true;
+        if (currentMode.get().equals(Mode.EDIT)) {
+            if (!selectedExpression.get().getName().equals(expressionNameTextField.getText())) {
+                saved = false;
+            }
+            if (!selectedExpression.get().getExcelExpressionString().equals(expressionString.get())) {
+                saved = false;
+            }
+            if (selectedExpression.get().isSquidSwitchNU() != NUSwitchCheckBox.isSelected()) {
+                saved = false;
+            }
+            if (selectedExpression.get().getExpressionTree().isSquidSwitchSTReferenceMaterialCalculation() != refMatSwitchCheckBox.isSelected()) {
+                saved = false;
+            }
+            if (selectedExpression.get().getExpressionTree().isSquidSwitchSAUnknownCalculation() != unknownsSwitchCheckBox.isSelected()) {
+                saved = false;
+            }
+            if (selectedExpression.get().getExpressionTree().isSquidSwitchConcentrationReferenceMaterialCalculation() != concRefMatSwitchCheckBox.isSelected()) {
+                saved = false;
+            }
+            if (selectedExpression.get().getExpressionTree().isSquidSwitchSCSummaryCalculation() != summaryCalculationSwitchCheckBox.isSelected()) {
+                saved = false;
+            }
+            if (selectedExpression.get().getExpressionTree().isSquidSpecialUPbThExpression() != specialUPbThSwitchCheckBox.isSelected()) {
+                saved = false;
+            }
+        }else if(currentMode.get().equals(Mode.CREATE)){
+            saved = false;
+        }
+        expressionIsSaved.set(saved);
     }
 
     private String makeStringFromTextFlow() {
@@ -2651,7 +2684,6 @@ public class ExpressionBuilderController implements Initializable {
                 @Override
                 public void updateItem(Expression expression, boolean empty) {
                     super.updateItem(expression, empty);
-                    System.out.println("updateItem");
                     if (empty) {
                         setText(null);
                         setGraphic(null);

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -1841,6 +1841,30 @@ public class ExpressionBuilderController implements Initializable {
             contextMenu.getItems().add(menuItem);
         }
 
+        if (!(etn instanceof NumberTextNode || etn instanceof OperationTextNode) && etn.getText().trim().matches("^\\[(±?)(%?)\"(.*)\"\\](\\[\\d\\])?$")) {
+            String text = etn.getText().trim().replaceAll("(^\\[(±?)(%?)\")|(\"\\](\\[\\d\\])?)", "");
+            Expression ex = squidProject.getTask().getExpressionByName(text);
+            if ((ex != null && ex.isSquidSwitchNU()) || squidProject.getTask().getRatioNames().contains(text)) {
+                MenuItem menuItem1 = new MenuItem("%");
+                menuItem1.setOnAction((evt) -> {
+                    ExpressionTextNode etn2 = new ExpressionTextNode(etn.getText().replaceAll("\\[(±?)(%?)\"", "[%\""));
+                    etn2.setOrdinalIndex(etn.getOrdinalIndex());
+                    expressionTextFlow.getChildren().remove(etn);
+                    expressionTextFlow.getChildren().add(etn2);
+                    updateExpressionTextFlowChildren();
+                });
+                MenuItem menuItem2 = new MenuItem("±");
+                menuItem2.setOnAction((evt) -> {
+                    ExpressionTextNode etn2 = new ExpressionTextNode(etn.getText().replaceAll("\\[(±?)(%?)\"", "[±\""));
+                    etn2.setOrdinalIndex(etn.getOrdinalIndex());
+                    expressionTextFlow.getChildren().remove(etn);
+                    expressionTextFlow.getChildren().add(etn2);
+                    updateExpressionTextFlowChildren();
+                });
+                contextMenu.getItems().add(new Menu("Set uncertainty...", null, menuItem1, menuItem2));
+            }
+        }
+
         // For numbers -> make an editable node
         if (etn instanceof NumberTextNode) {
             TextField editText = new TextField(etn.getText());
@@ -1928,15 +1952,19 @@ public class ExpressionBuilderController implements Initializable {
             text = text.replace(UNVISIBLEWHITESPACEPLACEHOLDER, " ");
             text = text.replace(VISIBLEWHITESPACEPLACEHOLDER, " ");
 
+            System.out.println(text);
             if (!text.matches("^[ \t\n\r]$")) {
                 text = nodeText.trim();
             }
+            
+            System.out.println(text);
 
             ImageView imageView = new ImageView(UNHEALTHY);
             imageView.setFitHeight(12);
             imageView.setFitWidth(12);
 
             TokenTypes type = ShuntingYard.TokenTypes.getType(text);
+            System.out.println(text);
             switch (type) {
 
                 case OPERATOR_A:
@@ -2012,7 +2040,7 @@ public class ExpressionBuilderController implements Initializable {
                     String exname = text;
                     String uncertainty = "";
                     if (text.matches("^\\[(±?)(%?)\"(.*?)\"\\]$")) {
-                        exname = text.replaceAll("(^\\[(%)?\")|(\"\\]$)", "");
+                        exname = text.replaceAll("(^\\[(%)?(±)?\")|(\"\\]$)", "");
                         if (text.contains("[%\"")) {
                             uncertainty = "1 \u03C3 % uncertainty\n\n";
                         } else if (text.contains("[±\"")) {

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -74,6 +74,7 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
@@ -475,6 +476,8 @@ public class ExpressionBuilderController implements Initializable {
 
     private Map<String, Tooltip> tooltipsMap = new HashMap<>();
 
+    private Map<KeyCode, Boolean> keyMap = new HashMap<>();
+
     //INIT
     @Override
     public void initialize(URL url, ResourceBundle rb) {
@@ -489,6 +492,7 @@ public class ExpressionBuilderController implements Initializable {
         initExpressionTextFlowAndTextArea();
         initGraph();
         initExpressionSelection();
+        initKey();
 
         currentMode.set(Mode.VIEW);
 
@@ -1090,6 +1094,18 @@ public class ExpressionBuilderController implements Initializable {
         });
         graphBrowserCheckBox.setOnAction((event) -> {
             graphExpressionTree(makeExpression().getExpressionTree());
+        });
+    }
+
+    private void initKey() {
+        for (KeyCode key : KeyCode.values()) {
+            keyMap.put(key, false);
+        }
+        mainPane.setOnKeyPressed((event) -> {
+            keyMap.put(event.getCode(), true);
+        });
+        mainPane.setOnKeyReleased((event) -> {
+            keyMap.put(event.getCode(), false);
         });
     }
 
@@ -2515,7 +2531,7 @@ public class ExpressionBuilderController implements Initializable {
 
         private void showToolTip(MouseEvent event, ListCell<Expression> cell, Tooltip t) {
             if (t != null) {
-                if (event.isControlDown()) {
+                if (keyMap.get(KeyCode.T)) {
                     t.show(cell, event.getScreenX() + 10, event.getScreenY() + 10);
                 } else {
                     hideToolTip(t, cell);
@@ -2725,7 +2741,7 @@ public class ExpressionBuilderController implements Initializable {
 
         private void showToolTip(MouseEvent event, ListCell<SquidRatiosModel> cell, Tooltip t) {
             if (t != null) {
-                if (event.isControlDown()) {
+                if (keyMap.get(KeyCode.T)) {
                     t.show(cell, event.getScreenX() + 10, event.getScreenY() + 10);
                 } else {
                     hideToolTip(t, cell);
@@ -2858,7 +2874,7 @@ public class ExpressionBuilderController implements Initializable {
 
         private void showToolTip(MouseEvent event, ListCell<String> cell, Tooltip t) {
             if (t != null) {
-                if (event.isControlDown()) {
+                if (keyMap.get(KeyCode.T)) {
                     t.show(cell, event.getScreenX() + 10, event.getScreenY() + 10);
                 } else {
                     hideToolTip(t, cell);
@@ -3141,7 +3157,7 @@ public class ExpressionBuilderController implements Initializable {
 
         private void showToolTip(MouseEvent event) {
             if (tooltip != null) {
-                if (event.isControlDown()) {
+                if (keyMap.get(KeyCode.T)) {
                     tooltip.show(this, event.getScreenX() + 10, event.getScreenY() + 10);
                 } else {
                     hideToolTip();

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -921,7 +921,7 @@ public class ExpressionBuilderController implements Initializable {
         expressionString.addListener((observable, oldValue, newValue) -> {
             if (newValue != null) {
                 expressionIsSaved.set(false);
-                buildTextFlowFromString(newValue);
+                makeTextFlowFromString(newValue);
                 if (!changeFromUndoRedo) {
                     if (oldValue != null) {
                         saveUndo(oldValue);
@@ -1253,7 +1253,7 @@ public class ExpressionBuilderController implements Initializable {
 
             //Rebuild because CSS doesnt apply
             expressionTextFlow.getChildren().clear();
-            buildTextFlowFromString(expressionString.get());
+            makeTextFlowFromString(expressionString.get());
         }
     }
 
@@ -2238,8 +2238,7 @@ public class ExpressionBuilderController implements Initializable {
         return sb.toString();
     }
 
-    private void buildTextFlowFromString(String string) {
-        String numberRegExp = "^\\d+(\\.\\d+)?$";
+    private void makeTextFlowFromString(String string) {
 
         List<Node> children = new ArrayList<>();
 
@@ -2255,7 +2254,7 @@ public class ExpressionBuilderController implements Initializable {
             ExpressionTextNode etn;
 
             // Make a node of the corresponding type
-            if (nodeText.matches(numberRegExp)) {
+            if (ShuntingYard.isNumber(nodeText) || NUMBERSTRING.equals(nodeText)) {
                 etn = new NumberTextNode(' ' + nodeText + ' ');
             } else if (listOperators.contains(nodeText)) {
                 etn = new OperationTextNode(' ' + nodeText + ' ');

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -2169,7 +2169,8 @@ public class ExpressionBuilderController implements Initializable {
         TaskInterface task = squidProject.getTask();
         //Remove if an expression already exists with the same name
         task.removeExpression(exp);
-        if (currentMode.get().equals(Mode.EDIT)) {
+        //Removes the old expression if the name has been changed
+        if (currentMode.get().equals(Mode.EDIT) && !exp.getName().equalsIgnoreCase(selectedExpression.get().getName())) {
             task.removeExpression(selectedExpression.get());
         }
         task.addExpression(exp);

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -1884,21 +1884,28 @@ public class ExpressionBuilderController implements Initializable {
                 for (int n = 0; n < peekString.length(); n++) {
                     if (peekString.charAt(n) == '\n') {
                         lineNumber++;
-                        if (lineNumber == 11) {
+                        if (lineNumber == 10) {
                             peekString = peekString.substring(0, n);
+                            peekString += "\n...";
+                            break;
                         }
                     }
                 }
                 peek += "Reference material :\n" + peekString + "\n";
             }
             if (ex.getExpressionTree().isSquidSwitchSAUnknownCalculation()) {
+                if (ex.getExpressionTree().isSquidSwitchConcentrationReferenceMaterialCalculation() || ex.getExpressionTree().isSquidSwitchSTReferenceMaterialCalculation()) {
+                    peek += "\n";
+                }
                 String peekString = createPeekUN(ex);
                 int lineNumber = 0;
                 for (int n = 0; n < peekString.length(); n++) {
                     if (peekString.charAt(n) == '\n') {
                         lineNumber++;
-                        if (lineNumber == 11) {
+                        if (lineNumber == 10) {
                             peekString = peekString.substring(0, n);
+                            peekString += "\n...";
+                            break;
                         }
                     }
                 }

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -2531,11 +2531,26 @@ public class ExpressionBuilderController implements Initializable {
 
                     MenuItem remove = new MenuItem("Remove expression");
                     remove.setOnAction((t) -> {
+                        int index = cell.getIndex();
+                        ListView parent = cell.getListView();
                         TaskInterface task = squidProject.getTask();
                         removedExpressions.add(cell.getItem());
                         task.removeExpression(cell.getItem());
                         selectedExpression.set(null);
                         populateExpressionListViews();
+
+                        //Determines the new expression to select
+                        int size = parent.getItems().size();
+                        if (size <= index) {
+                            index = size - 1;
+                        }
+                        if (index >= 0) {
+                            selectInAllPanes((Expression) parent.getItems().get(index), false);
+                        } else {
+                            if (namedExpressions.size() > 0) {
+                                selectInAllPanes(namedExpressions.get(0), true);
+                            }
+                        }
                     });
                     cm.getItems().add(remove);
 

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -725,77 +725,104 @@ public class ExpressionBuilderController implements Initializable {
         globalListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
 
         //Selection listener to update the categories tab when a new value is selected on the filter tab
-        globalListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null) {
+        globalListView.getSelectionModel().getSelectedItems().addListener((new ListChangeListener<Expression>() {
+            @Override
+            public void onChanged(ListChangeListener.Change<? extends Expression> exp) {
 
-                if (currentMode.get().equals(Mode.VIEW)) {
-                    selectedExpressionIsEditable.set(true);
-                    //The new value is selected to be shown in the editor
-                    selectedExpression.set(newValue);
+                ObservableList<Expression> selected = globalListView.getSelectionModel().getSelectedItems();
+                if (selected.size() > 0) {
+                    if (currentMode.get().equals(Mode.VIEW)) {
+                        selectedExpressionIsEditable.set(true);
+                        //The new value is selected to be shown in the editor
+                        selectedExpression.set(selected.get(0));
+                    }
+
+                    selectInAllPanes(selectedExpression.get(), false);
                 }
-
-                selectInAllPanes(newValue, false);
             }
-        });
+        }));
 
         brokenExpressionsListView.setStyle(SquidUI.EXPRESSION_LIST_CSS_STYLE_SPECS);
         brokenExpressionsListView.setCellFactory(new ExpressionCellFactory(true));
         brokenExpressionsListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         //Listener to update the filter tab when a new value is selected in the broken expression category
-        brokenExpressionsListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null) {
-                if (currentMode.get().equals(Mode.VIEW)) {
-                    selectedExpressionIsEditable.set(true);
-                    //The new value is selected to be shown in the editor
-                    selectedExpression.set(newValue);
-                }
+        brokenExpressionsListView.getSelectionModel().getSelectedItems().addListener((new ListChangeListener<Expression>() {
+            @Override
+            public void onChanged(ListChangeListener.Change<? extends Expression> exp) {
 
-                selectInAllPanes(newValue, false);
+                ObservableList<Expression> selected = brokenExpressionsListView.getSelectionModel().getSelectedItems();
+                if (selected.size() > 0) {
+                    if (currentMode.get().equals(Mode.VIEW)) {
+                        selectedExpressionIsEditable.set(true);
+                        //The new value is selected to be shown in the editor
+                        selectedExpression.set(selected.get(0));
+                    }
+
+                    selectInAllPanes(selectedExpression.get(), false);
+                }
             }
-        });
+        }));
 
         nuSwitchedExpressionsListView.setStyle(SquidUI.EXPRESSION_LIST_CSS_STYLE_SPECS);
         nuSwitchedExpressionsListView.setCellFactory(new ExpressionCellFactory());
         nuSwitchedExpressionsListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         //Same listener for each category
-        nuSwitchedExpressionsListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null) {
-                if (currentMode.get().equals(Mode.VIEW)) {
-                    selectedExpressionIsEditable.set(true);
-                    selectedExpression.set(newValue);
-                }
+        nuSwitchedExpressionsListView.getSelectionModel().getSelectedItems().addListener((new ListChangeListener<Expression>() {
+            @Override
+            public void onChanged(ListChangeListener.Change<? extends Expression> exp) {
 
-                selectInAllPanes(newValue, false);
+                ObservableList<Expression> selected = nuSwitchedExpressionsListView.getSelectionModel().getSelectedItems();
+                if (selected.size() > 0) {
+                    if (currentMode.get().equals(Mode.VIEW)) {
+                        selectedExpressionIsEditable.set(true);
+                        //The new value is selected to be shown in the editor
+                        selectedExpression.set(selected.get(0));
+                    }
+
+                    selectInAllPanes(selectedExpression.get(), false);
+                }
             }
-        });
+        }));
 
         builtInExpressionsListView.setStyle(SquidUI.EXPRESSION_LIST_CSS_STYLE_SPECS);
         builtInExpressionsListView.setCellFactory(new ExpressionCellFactory());
         builtInExpressionsListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
-        builtInExpressionsListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null) {
-                if (currentMode.get().equals(Mode.VIEW)) {
-                    selectedExpressionIsEditable.set(true);
-                    selectedExpression.set(newValue);
-                }
+        builtInExpressionsListView.getSelectionModel().getSelectedItems().addListener((new ListChangeListener<Expression>() {
+            @Override
+            public void onChanged(ListChangeListener.Change<? extends Expression> exp) {
 
-                selectInAllPanes(newValue, false);
+                ObservableList<Expression> selected = builtInExpressionsListView.getSelectionModel().getSelectedItems();
+                if (selected.size() > 0) {
+                    if (currentMode.get().equals(Mode.VIEW)) {
+                        selectedExpressionIsEditable.set(true);
+                        //The new value is selected to be shown in the editor
+                        selectedExpression.set(selected.get(0));
+                    }
+
+                    selectInAllPanes(selectedExpression.get(), false);
+                }
             }
-        });
+        }));
 
         customExpressionsListView.setStyle(SquidUI.EXPRESSION_LIST_CSS_STYLE_SPECS);
         customExpressionsListView.setCellFactory(new ExpressionCellFactory());
         customExpressionsListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
-        customExpressionsListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null) {
-                if (currentMode.get().equals(Mode.VIEW)) {
-                    selectedExpressionIsEditable.set(true);
-                    selectedExpression.set(newValue);
-                }
+        customExpressionsListView.getSelectionModel().getSelectedItems().addListener((new ListChangeListener<Expression>() {
+            @Override
+            public void onChanged(ListChangeListener.Change<? extends Expression> exp) {
 
-                selectInAllPanes(newValue, false);
+                ObservableList<Expression> selected = customExpressionsListView.getSelectionModel().getSelectedItems();
+                if (selected.size() > 0) {
+                    if (currentMode.get().equals(Mode.VIEW)) {
+                        selectedExpressionIsEditable.set(true);
+                        //The new value is selected to be shown in the editor
+                        selectedExpression.set(selected.get(0));
+                    }
+
+                    selectInAllPanes(selectedExpression.get(), false);
+                }
             }
-        });
+        }));
 
         populateExpressionListViews();
 
@@ -803,20 +830,27 @@ public class ExpressionBuilderController implements Initializable {
         ratioExpressionsListView.setStyle(SquidUI.EXPRESSION_LIST_CSS_STYLE_SPECS);
         ratioExpressionsListView.setCellFactory(new ExpressionTreeCellFactory());
         ratioExpressionsListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
-        ratioExpressionsListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null) {
-                if (currentMode.get().equals(Mode.VIEW)) {
-                    Expression exp = new Expression(squidProject.getTask().getNamedExpressionsMap().get(newValue.getRatioName()), "[\"" + newValue.getRatioName() + "\"]", false);
-                    exp.getExpressionTree().setSquidSpecialUPbThExpression(true);
-                    exp.getExpressionTree().setSquidSwitchSTReferenceMaterialCalculation(true);
-                    exp.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+        ratioExpressionsListView.getSelectionModel().getSelectedItems().addListener((new ListChangeListener<SquidRatiosModel>() {
+            @Override
+            public void onChanged(ListChangeListener.Change<? extends SquidRatiosModel> exp) {
 
-                    selectedExpressionIsEditable.set(false);
-                    selectedExpression.set(exp);
+                ObservableList<SquidRatiosModel> selected = ratioExpressionsListView.getSelectionModel().getSelectedItems();
+                if (selected.size() > 0) {
+                    if (currentMode.get().equals(Mode.VIEW)) {
+                        Expression expr = new Expression(squidProject.getTask().getNamedExpressionsMap().get(selected.get(0).getRatioName()), "[\"" + selected.get(0).getRatioName() + "\"]", false);
+                        expr.getExpressionTree().setSquidSpecialUPbThExpression(true);
+                        expr.getExpressionTree().setSquidSwitchSTReferenceMaterialCalculation(true);
+                        expr.getExpressionTree().setSquidSwitchSAUnknownCalculation(true);
+                        //The new value is selected to be shown in the editor
+                        selectedExpressionIsEditable.set(false);
+                        selectedExpression.set(expr);
+                    }
+
+                    selectInAllPanes(null, false);
                 }
-                selectInAllPanes(null, false);
             }
-        });
+        }));
+
         populateRatiosListView();
 
         //OPERATIONS AND FUNCTIONS
@@ -2617,6 +2651,7 @@ public class ExpressionBuilderController implements Initializable {
                 @Override
                 public void updateItem(Expression expression, boolean empty) {
                     super.updateItem(expression, empty);
+                    System.out.println("updateItem");
                     if (empty) {
                         setText(null);
                         setGraphic(null);

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -473,6 +473,8 @@ public class ExpressionBuilderController implements Initializable {
 
     public static Expression expressionToHighlightOnInit = null;
 
+    private Map<String, Tooltip> tooltipsMap = new HashMap<>();
+
     //INIT
     @Override
     public void initialize(URL url, ResourceBundle rb) {
@@ -932,7 +934,7 @@ public class ExpressionBuilderController implements Initializable {
                 updateEditor();
             }
         });
-        
+
         expressionNameTextField.textProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue != null) {
                 expressionIsSaved.set(false);
@@ -1374,6 +1376,9 @@ public class ExpressionBuilderController implements Initializable {
 
     //POPULATE LISTS
     private void populateExpressionListViews() {
+
+        tooltipsMap.clear();
+
         namedExpressions = FXCollections.observableArrayList(squidProject.getTask().getTaskExpressionsOrdered());
 
         List<Expression> sortedNUSwitchedExpressionsList = new ArrayList<>();
@@ -1907,8 +1912,8 @@ public class ExpressionBuilderController implements Initializable {
     }
 
     private Tooltip createFloatingTooltip(String nodeText) {
-        Tooltip res = null;
-        if (nodeText != null) {
+        Tooltip res = tooltipsMap.get(nodeText);
+        if (nodeText != null && res == null) {
             String text = nodeText.replace(UNVISIBLENEWLINEPLACEHOLDER, "\n");
             text = text.replace(VISIBLENEWLINEPLACEHOLDER, "\n");
             text = text.replace(UNVISIBLETABPLACEHOLDER, "\t");
@@ -2058,6 +2063,7 @@ public class ExpressionBuilderController implements Initializable {
                 res.setGraphic(imageView);
             }
             res.setStyle(EXPRESSION_TOOLTIP_CSS_STYLE_SPECS);
+            tooltipsMap.put(nodeText, res);
         }
         return res;
     }
@@ -2419,8 +2425,6 @@ public class ExpressionBuilderController implements Initializable {
         public ListCell<Expression> call(ListView<Expression> param) {
             ListCell<Expression> cell = new ListCell<Expression>() {
 
-                boolean updated = false;
-
                 @Override
                 public void updateItem(Expression expression, boolean empty) {
                     super.updateItem(expression, empty);
@@ -2428,32 +2432,29 @@ public class ExpressionBuilderController implements Initializable {
                         setText(null);
                         setGraphic(null);
                     } else {
-                        if (!updated) {
-                            updated = true;
-                            setText(expression.getName());
-                            if (showImage) {
-                                ImageView imageView;
-                                if (expression.amHealthy()) {
-                                    imageView = new ImageView(HEALTHY);
+                        setText(expression.getName());
+                        if (showImage) {
+                            ImageView imageView;
+                            if (expression.amHealthy()) {
+                                imageView = new ImageView(HEALTHY);
 
-                                } else {
-                                    imageView = new ImageView(UNHEALTHY);
-                                }
-                                imageView.setFitHeight(12);
-                                imageView.setFitWidth(12);
-                                setGraphic(imageView);
+                            } else {
+                                imageView = new ImageView(UNHEALTHY);
                             }
-                            Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
-                            setOnMouseEntered((event) -> {
-                                showToolTip(event, this, t);
-                            });
-                            setOnMouseExited((event) -> {
-                                hideToolTip(t, this);
-                            });
-                            setOnMouseMoved((event) -> {
-                                showToolTip(event, this, t);
-                            });
+                            imageView.setFitHeight(12);
+                            imageView.setFitWidth(12);
+                            setGraphic(imageView);
                         }
+                        Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
+                        setOnMouseEntered((event) -> {
+                            showToolTip(event, this, t);
+                        });
+                        setOnMouseExited((event) -> {
+                            hideToolTip(t, this);
+                        });
+                        setOnMouseMoved((event) -> {
+                            showToolTip(event, this, t);
+                        });
                     }
                 }
             };
@@ -2634,27 +2635,22 @@ public class ExpressionBuilderController implements Initializable {
                 @Override
                 public void updateItem(SquidRatiosModel expression, boolean empty) {
 
-                    boolean updated = false;
-
                     super.updateItem(expression, empty);
                     if (empty) {
                         setText(null);
                         setGraphic(null);
                     } else {
-                        if (!updated) {
-                            updated = true;
-                            setText(expression.getRatioName());
-                            Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
-                            setOnMouseEntered((event) -> {
-                                showToolTip(event, this, t);
-                            });
-                            setOnMouseExited((event) -> {
-                                hideToolTip(t, this);
-                            });
-                            setOnMouseMoved((event) -> {
-                                showToolTip(event, this, t);
-                            });
-                        }
+                        setText(expression.getRatioName());
+                        Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
+                        setOnMouseEntered((event) -> {
+                            showToolTip(event, this, t);
+                        });
+                        setOnMouseExited((event) -> {
+                            hideToolTip(t, this);
+                        });
+                        setOnMouseMoved((event) -> {
+                            showToolTip(event, this, t);
+                        });
                     }
                 }
             };
@@ -2770,8 +2766,6 @@ public class ExpressionBuilderController implements Initializable {
         public ListCell<String> call(ListView<String> param) {
             ListCell<String> cell = new ListCell<String>() {
 
-                boolean updated = false;
-
                 @Override
                 public void updateItem(String operationOrFunction, boolean empty) {
                     super.updateItem(operationOrFunction, empty);
@@ -2779,21 +2773,18 @@ public class ExpressionBuilderController implements Initializable {
                         setText(null);
                         setGraphic(null);
                     } else {
-                        if (!updated) {
-                            updated = true;
-                            setText(operationOrFunction);
-                            System.out.println("\"" + getText().replaceAll("(:.*|\\(.*\\))$", "") + "\"");
-                            Tooltip t = createFloatingTooltip(getText().replaceAll("(:.*|\\(.*\\))$", "").trim().replaceAll("Tab", VISIBLETABPLACEHOLDER).replaceAll("New line", VISIBLENEWLINEPLACEHOLDER).replaceAll("White space", VISIBLEWHITESPACEPLACEHOLDER));
-                            setOnMouseEntered((event) -> {
-                                showToolTip(event, this, t);
-                            });
-                            setOnMouseExited((event) -> {
-                                hideToolTip(t, this);
-                            });
-                            setOnMouseMoved((event) -> {
-                                showToolTip(event, this, t);
-                            });
-                        }
+                        setText(operationOrFunction);
+                        System.out.println("\"" + getText().replaceAll("(:.*|\\(.*\\))$", "") + "\"");
+                        Tooltip t = createFloatingTooltip(getText().replaceAll("(:.*|\\(.*\\))$", "").trim().replaceAll("Tab", VISIBLETABPLACEHOLDER).replaceAll("New line", VISIBLENEWLINEPLACEHOLDER).replaceAll("White space", VISIBLEWHITESPACEPLACEHOLDER));
+                        setOnMouseEntered((event) -> {
+                            showToolTip(event, this, t);
+                        });
+                        setOnMouseExited((event) -> {
+                            hideToolTip(t, this);
+                        });
+                        setOnMouseMoved((event) -> {
+                            showToolTip(event, this, t);
+                        });
                     }
                 }
             };

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -2027,7 +2027,7 @@ public class ExpressionBuilderController implements Initializable {
                     //case expression
                     if (ex != null) {
                         boolean isCustom = ex.isCustom();
-                        res = new Tooltip((isCustom ? "Custom expression: " : "Expression: ") + ex.getName() + "\n\n" + uncertainty + (ex.amHealthy() ? createPeekForTooltip(ex) : ex.produceExpressionTreeAudit().trim()) + "\n\nNotes:\n" + (ex.getNotes().equals("") ? "none" : ex.getNotes()));
+                        res = new Tooltip((isCustom ? "Custom expression: " : "Expression: ") + "\n\n" + ex.getName() + "\n\nExpression string: " + ex.getExcelExpressionString() + "\n\n" + uncertainty + (ex.amHealthy() ? createPeekForTooltip(ex) : ex.produceExpressionTreeAudit().trim()) + "\n\nNotes:\n" + (ex.getNotes().equals("") ? "none" : ex.getNotes()));
                         if (!ex.amHealthy()) {
                             res.setGraphic(imageView);
                         }

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -2406,6 +2406,9 @@ public class ExpressionBuilderController implements Initializable {
         @Override
         public ListCell<Expression> call(ListView<Expression> param) {
             ListCell<Expression> cell = new ListCell<Expression>() {
+
+                boolean updated = false;
+
                 @Override
                 public void updateItem(Expression expression, boolean empty) {
                     super.updateItem(expression, empty);
@@ -2413,29 +2416,32 @@ public class ExpressionBuilderController implements Initializable {
                         setText(null);
                         setGraphic(null);
                     } else {
-                        setText(expression.getName());
-                        if (showImage) {
-                            ImageView imageView;
-                            if (expression.amHealthy()) {
-                                imageView = new ImageView(HEALTHY);
+                        if (!updated) {
+                            updated = true;
+                            setText(expression.getName());
+                            if (showImage) {
+                                ImageView imageView;
+                                if (expression.amHealthy()) {
+                                    imageView = new ImageView(HEALTHY);
 
-                            } else {
-                                imageView = new ImageView(UNHEALTHY);
+                                } else {
+                                    imageView = new ImageView(UNHEALTHY);
+                                }
+                                imageView.setFitHeight(12);
+                                imageView.setFitWidth(12);
+                                setGraphic(imageView);
                             }
-                            imageView.setFitHeight(12);
-                            imageView.setFitWidth(12);
-                            setGraphic(imageView);
+                            Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
+                            setOnMouseEntered((event) -> {
+                                showToolTip(event, this, t);
+                            });
+                            setOnMouseExited((event) -> {
+                                hideToolTip(t, this);
+                            });
+                            setOnMouseMoved((event) -> {
+                                showToolTip(event, this, t);
+                            });
                         }
-                        Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
-                        setOnMouseEntered((event) -> {
-                            showToolTip(event, this, t);
-                        });
-                        setOnMouseExited((event) -> {
-                            hideToolTip(t, this);
-                        });
-                        setOnMouseMoved((event) -> {
-                            showToolTip(event, this, t);
-                        });
                     }
                 }
             };
@@ -2615,22 +2621,28 @@ public class ExpressionBuilderController implements Initializable {
             ListCell<SquidRatiosModel> cell = new ListCell<SquidRatiosModel>() {
                 @Override
                 public void updateItem(SquidRatiosModel expression, boolean empty) {
+
+                    boolean updated = false;
+
                     super.updateItem(expression, empty);
                     if (empty) {
                         setText(null);
                         setGraphic(null);
                     } else {
-                        setText(expression.getRatioName());
-                        Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
-                        setOnMouseEntered((event) -> {
-                            showToolTip(event, this, t);
-                        });
-                        setOnMouseExited((event) -> {
-                            hideToolTip(t, this);
-                        });
-                        setOnMouseMoved((event) -> {
-                            showToolTip(event, this, t);
-                        });
+                        if (!updated) {
+                            updated = true;
+                            setText(expression.getRatioName());
+                            Tooltip t = createFloatingTooltip("[\"" + getText() + "\"]");
+                            setOnMouseEntered((event) -> {
+                                showToolTip(event, this, t);
+                            });
+                            setOnMouseExited((event) -> {
+                                hideToolTip(t, this);
+                            });
+                            setOnMouseMoved((event) -> {
+                                showToolTip(event, this, t);
+                            });
+                        }
                     }
                 }
             };
@@ -2745,6 +2757,9 @@ public class ExpressionBuilderController implements Initializable {
         @Override
         public ListCell<String> call(ListView<String> param) {
             ListCell<String> cell = new ListCell<String>() {
+
+                boolean updated = false;
+
                 @Override
                 public void updateItem(String operationOrFunction, boolean empty) {
                     super.updateItem(operationOrFunction, empty);
@@ -2752,18 +2767,21 @@ public class ExpressionBuilderController implements Initializable {
                         setText(null);
                         setGraphic(null);
                     } else {
-                        setText(operationOrFunction);
-                        System.out.println("\"" + getText().replaceAll("(:.*|\\(.*\\))$", "") + "\"");
-                        Tooltip t = createFloatingTooltip(getText().replaceAll("(:.*|\\(.*\\))$", "").trim().replaceAll("Tab", VISIBLETABPLACEHOLDER).replaceAll("New line", VISIBLENEWLINEPLACEHOLDER).replaceAll("White space", VISIBLEWHITESPACEPLACEHOLDER));
-                        setOnMouseEntered((event) -> {
-                            showToolTip(event, this, t);
-                        });
-                        setOnMouseExited((event) -> {
-                            hideToolTip(t, this);
-                        });
-                        setOnMouseMoved((event) -> {
-                            showToolTip(event, this, t);
-                        });
+                        if (!updated) {
+                            updated = true;
+                            setText(operationOrFunction);
+                            System.out.println("\"" + getText().replaceAll("(:.*|\\(.*\\))$", "") + "\"");
+                            Tooltip t = createFloatingTooltip(getText().replaceAll("(:.*|\\(.*\\))$", "").trim().replaceAll("Tab", VISIBLETABPLACEHOLDER).replaceAll("New line", VISIBLENEWLINEPLACEHOLDER).replaceAll("White space", VISIBLEWHITESPACEPLACEHOLDER));
+                            setOnMouseEntered((event) -> {
+                                showToolTip(event, this, t);
+                            });
+                            setOnMouseExited((event) -> {
+                                hideToolTip(t, this);
+                            });
+                            setOnMouseMoved((event) -> {
+                                showToolTip(event, this, t);
+                            });
+                        }
                     }
                 }
             };

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -510,7 +510,7 @@ public class ExpressionBuilderController implements Initializable {
         createExpressionBtn.disableProperty().bind(currentMode.isNotEqualTo(Mode.VIEW));
         expressionClearBtn.disableProperty().bind(currentMode.isEqualTo(Mode.VIEW));
         expressionPasteBtn.disableProperty().bind(currentMode.isEqualTo(Mode.VIEW));
-        saveBtn.disableProperty().bind(currentMode.isEqualTo(Mode.VIEW).or(expressionNameTextField.textProperty().isEmpty()));
+        saveBtn.disableProperty().bind(currentMode.isEqualTo(Mode.VIEW).or(expressionNameTextField.textProperty().isEmpty()).or(expressionIsSaved));
         expressionAsTextBtn.disableProperty().bind(currentMode.isEqualTo(Mode.VIEW));
         refMatSwitchCheckBox.disableProperty().bind(currentMode.isEqualTo(Mode.VIEW));
         unknownsSwitchCheckBox.disableProperty().bind(currentMode.isEqualTo(Mode.VIEW));
@@ -920,6 +920,7 @@ public class ExpressionBuilderController implements Initializable {
         expressionAsTextArea.textProperty().bindBidirectional(expressionString);
         expressionString.addListener((observable, oldValue, newValue) -> {
             if (newValue != null) {
+                expressionIsSaved.set(false);
                 buildTextFlowFromString(newValue);
                 if (!changeFromUndoRedo) {
                     if (oldValue != null) {
@@ -929,6 +930,12 @@ public class ExpressionBuilderController implements Initializable {
                     changeFromUndoRedo = false;
                 }
                 updateEditor();
+            }
+        });
+        
+        expressionNameTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null) {
+                expressionIsSaved.set(false);
             }
         });
 
@@ -1113,6 +1120,7 @@ public class ExpressionBuilderController implements Initializable {
     private void editCustomExpressionAction(ActionEvent event) {
         if (selectedExpressionIsEditable.get() && currentMode.get().equals(Mode.VIEW)) {
             currentMode.set(Mode.EDIT);
+            expressionIsSaved.set(true);
         }
     }
 
@@ -1273,32 +1281,37 @@ public class ExpressionBuilderController implements Initializable {
     @FXML
     private void referenceMaterialCheckBoxAction(ActionEvent event) {
         concRefMatSwitchCheckBox.setSelected(false);
+        expressionIsSaved.set(false);
     }
 
     @FXML
     private void unknownSamplesCheckBoxAction(ActionEvent event) {
         concRefMatSwitchCheckBox.setSelected(false);
+        expressionIsSaved.set(false);
     }
 
     @FXML
     private void concRefMatCheckBoxAction(ActionEvent event) {
         unknownsSwitchCheckBox.setSelected(false);
         refMatSwitchCheckBox.setSelected(false);
+        expressionIsSaved.set(false);
     }
 
     @FXML
     private void summaryCalculationCheckBoxAction(ActionEvent event) {
         NUSwitchCheckBox.setSelected(false);
+        expressionIsSaved.set(false);
     }
 
     @FXML
     private void specialUPbThCheckBoxAction(ActionEvent event) {
-
+        expressionIsSaved.set(false);
     }
 
     @FXML
     private void NUSwitchCheckBoxAction(ActionEvent event) {
         summaryCalculationSwitchCheckBox.setSelected(false);
+        expressionIsSaved.set(false);
     }
 
     @FXML

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -1318,7 +1318,7 @@ public class ExpressionBuilderController implements Initializable {
 
     @FXML
     private void howToUseAction(ActionEvent event) {
-
+        BrowserControl.showURI("https://www.youtube.com/playlist?list=PLfF8bcNRe2WTWx2IuDaHW_XpLh36bWkUc");
     }
 
     @FXML

--- a/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
@@ -175,7 +175,7 @@
                               <Button fx:id="editExpressionBtn" mnemonicParsing="false" onAction="#editCustomExpressionAction" text="Edit" />
                               <Button fx:id="cancelBtn" mnemonicParsing="false" onAction="#cancelAction" text="Cancel" />
                               <Button fx:id="saveBtn" mnemonicParsing="false" onAction="#saveAction" text="Save" />
-                              <Button alignment="CENTER" mnemonicParsing="false" onAction="#howToUseAction" text="How to use?" HBox.hgrow="NEVER" />
+                              <Button alignment="CENTER" mnemonicParsing="false" onAction="#howToUseAction" text="HowTo Videos" HBox.hgrow="NEVER" />
                            </children>
                         </HBox>
                         <HBox fx:id="toolBarHBox" alignment="CENTER_LEFT" spacing="6.0">

--- a/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
@@ -219,14 +219,23 @@
                      <items>
                         <VBox>
                            <children>
-                              <Text fx:id="hintHoverText" strokeType="OUTSIDE" strokeWidth="0.0" text="Hint: ctrl+hover a node to show detail">
-                                 <font>
-                                    <Font size="11.0" />
-                                 </font>
+                              <HBox>
                                  <VBox.margin>
                                     <Insets left="2.0" />
                                  </VBox.margin>
-                              </Text>
+                                 <children>
+                                    <Text fx:id="hintHoverText" strokeType="OUTSIDE" strokeWidth="0.0" text="Hint: hold t + hover a node to show detail">
+                                       <font>
+                                          <Font size="11.0" />
+                                       </font>
+                                    </Text>
+                                    <Text fx:id="hintSelectText" layoutX="10.0" layoutY="21.0" strokeType="OUTSIDE" strokeWidth="0.0" text=" - hold ctrl for multi-selection">
+                                       <font>
+                                          <Font size="11.0" />
+                                       </font>
+                                    </Text>
+                                 </children>
+                              </HBox>
                               <AnchorPane VBox.vgrow="ALWAYS">
                                  <children>
                                     <TitledPane animated="false" collapsible="false" layoutY="2.5" minHeight="70.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">


### PR DESCRIPTION
Bug fixes:
- Return focus to an other expression after removing - #101 
- Prevent from re-building tooltips on list views items - #102 
- Fix context menu for 'NUMBER' - #106 
- Prevent from saving when nothing changed - #100 
- Eliminate unneeded call to remove expression - #103 

Enhancements:
- Multi selection of drag and drop entities - #98 
- Show % uncertainty in tooltips when needed - #91 
- Add modifier for % and ± uncertainties - #93 
- Refine presentation of lists of spots - #95 
- Add link on HowTo Videos button - #96 