### PR TITLE
Adjusts foreign language fonts for Linux and Windows for splash screen

### DIFF
--- a/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
@@ -211,7 +211,7 @@
                      <children>
                         <VBox alignment="CENTER">
                            <children>
-                              <Label fx:id="chinese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28;" text="墨斗鱼">
+                              <Label fx:id="chinese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="墨斗鱼">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>
@@ -221,7 +221,7 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="584.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="japanese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28;" text="いか">
+                              <Label fx:id="japanese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="いか">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>
@@ -234,7 +234,7 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="605.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="korean" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28;" text="오징어">
+                              <Label fx:id="korean" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="오징어">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>
@@ -247,7 +247,7 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="734.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="japanese1" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="200.0" style="-fx-text-fill: white; -fx-font-size: 28;" text="kałamarnica">
+                              <Label fx:id="japanese1" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="200.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="kałamarnica">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>
@@ -257,7 +257,7 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="823.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="japanese11" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28;" text="lula">
+                              <Label fx:id="japanese11" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="lula">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>
@@ -267,9 +267,9 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="912.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="japanese111" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28;" text="кальмар">
+                              <Label fx:id="japanese111" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="кальмар">
                                  <font>
-                                    <Font name="System Bold" size="14.0" />
+                                    <Font name="Lucida Sans Demibold" size="14.0" />
                                  </font>
                               </Label>
                               <Label style="-fx-text-fill: white;" text="Russian" />
@@ -277,7 +277,7 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="1001.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="japanese1111" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28;" text="calamar">
+                              <Label fx:id="japanese1111" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="calamar">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>

--- a/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
@@ -211,7 +211,7 @@
                      <children>
                         <VBox alignment="CENTER">
                            <children>
-                              <Label fx:id="chinese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="墨斗鱼">
+                              <Label fx:id="chinese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans; -fx-font-weight: bold;" text="墨斗鱼">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>
@@ -221,7 +221,7 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="584.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="japanese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="いか">
+                              <Label fx:id="japanese" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans; -fx-font-weight: bold;" text="いか">
                                  <font>
                                     <Font name="System Bold" size="14.0" />
                                  </font>
@@ -234,9 +234,9 @@
                         </VBox>
                         <VBox alignment="CENTER" layoutX="605.0" layoutY="10.0">
                            <children>
-                              <Label fx:id="korean" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: Lucida Sans;" text="오징어">
+                              <Label fx:id="korean" alignment="CENTER" contentDisplay="CENTER" prefHeight="40.0" prefWidth="160.0" style="-fx-text-fill: white; -fx-font-size: 28; -fx-font-family: SansSerif; -fx-font-weight: bold;" text="오징어">
                                  <font>
-                                    <Font name="System Bold" size="14.0" />
+                                    <Font name="SansSerif Bold" size="14.0" />
                                  </font>
                               </Label>
                               <Label style="-fx-text-fill: white;" text="Korean" />


### PR DESCRIPTION
Linux users will have to install Korean fonts, which do not ship natively.