### PR TITLE
Requested Improvements

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -6,7 +6,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 String mavenGroupId = 'org.cirdles'
-String mavenVersion = '1.1.8'
+String mavenVersion = '1.1.9'
 
 sourceCompatibility = '1.8'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'

--- a/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
@@ -1371,6 +1371,8 @@ public class SquidUIController implements Initializable {
                 squidProject.getTask().setChanged(true);
                 squidProject.getTask().setupSquidSessionSpecsAndReduceAndReport();
                 squidPersistentState.updatePrawnFileListMRU(prawnXMLFileNew);
+                squidProject.autoDivideSamples();
+                squidProject.setProjectName("NEW PROJECT");
                 launchProjectManager();
                 saveSquidProjectMenuItem.setDisable(true);
             }

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -98,11 +98,9 @@ import static org.cirdles.squid.tasks.expressions.functions.Function.*;
 import static org.cirdles.squid.tasks.expressions.operations.Operation.OPERATIONS_MAP;
 import static org.cirdles.squid.utilities.conversionUtilities.CloningUtilities.clone2dArray;
 
-
 import org.cirdles.squid.tasks.Task;
 import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeBuilderInterface;
 import org.cirdles.squid.tasks.expressions.operations.Value;
-
 
 /**
  * FXML Controller class
@@ -1611,10 +1609,17 @@ public class ExpressionBuilderController implements Initializable {
         List<String> squidFunctionStrings = new ArrayList<>();
         for (Map.Entry<String, String> op : SQUID_FUNCTIONS_MAP.entrySet()) {
             int argumentCount = Function.operationFactory(op.getValue()).getArgumentCount();
+            String[] inputLabels = Function.operationFactory(op.getValue()).getLabelsForInputValues();
             StringBuilder args = new StringBuilder();
             args.append(op.getKey()).append("(");
             for (int i = 0; i < argumentCount; i++) {
-                args.append("Arg").append(i).append(i < (argumentCount - 1) ? "," : ")");
+                if ((inputLabels.length > i)  &&   inputLabels[i].indexOf("default") > 0) {
+                    String[] defaultValue = inputLabels[i].split("=");
+                    args.append(defaultValue[1].trim());
+                } else {
+                    args.append("Arg").append(i);
+                }
+                args.append(i < (argumentCount - 1) ? "," : ")");
             }
 
             squidFunctionStrings.add(args.toString());
@@ -2575,10 +2580,10 @@ public class ExpressionBuilderController implements Initializable {
                         if (fn != null) {
                             tooltip = new Tooltip(
                                     "Function: " + fn.getName()
-                                            + "\n\n" + fn.getArgumentCount()
-                                            + " argument(s): " + fn.printInputValues().trim()
-                                            + "\nOutputs: " + fn.printOutputValues().trim()
-                                            + "\nDefinition: " + fn.getDefinition().trim());
+                                    + "\n\n" + fn.getArgumentCount()
+                                    + " argument(s): " + fn.printInputValues().trim()
+                                    + "\nOutputs: " + fn.printOutputValues().trim()
+                                    + "\nDefinition: " + fn.getDefinition().trim());
                         }
                     }
                     break;
@@ -2650,21 +2655,21 @@ public class ExpressionBuilderController implements Initializable {
                         ExpressionTreeInterface expTree = ex.getExpressionTree();
                         tooltip = new Tooltip(
                                 (isCustom ? "Custom expression: " : "Expression: ")
-                                        + "  " + ex.getName()
-                                        + "\n  Targets: "
-                                        + (expTree.isSquidSwitchConcentrationReferenceMaterialCalculation() ? "C" : "")
-                                        + (expTree.isSquidSwitchSTReferenceMaterialCalculation() ? "R" : "")
-                                        + (expTree.isSquidSwitchSAUnknownCalculation() ? "U" : "")
-                                        + "    Type: " + (expTree.isSquidSwitchSCSummaryCalculation() ? "Summary " : "")
-                                        + (ex.isSquidSwitchNU() ? "NU-switched " : "")
-                                        + (expTree.isSquidSpecialUPbThExpression() ? "Built-In" : "")
-                                        + "\n\nExpression string: "
-                                        + ex.getExcelExpressionString()
-                                        + "\n"
-                                        + uncertainty
-                                        + (ex.amHealthy() ? createPeekForTooltip(ex) : customizeExpressionTreeAudit(ex).trim())
-                                        + "\nNotes:\n"
-                                        + (ex.getNotes().equals("") ? "none" : ex.getNotes()));
+                                + "  " + ex.getName()
+                                + "\n  Targets: "
+                                + (expTree.isSquidSwitchConcentrationReferenceMaterialCalculation() ? "C" : "")
+                                + (expTree.isSquidSwitchSTReferenceMaterialCalculation() ? "R" : "")
+                                + (expTree.isSquidSwitchSAUnknownCalculation() ? "U" : "")
+                                + "    Type: " + (expTree.isSquidSwitchSCSummaryCalculation() ? "Summary " : "")
+                                + (ex.isSquidSwitchNU() ? "NU-switched " : "")
+                                + (expTree.isSquidSpecialUPbThExpression() ? "Built-In" : "")
+                                + "\n\nExpression string: "
+                                + ex.getExcelExpressionString()
+                                + "\n"
+                                + uncertainty
+                                + (ex.amHealthy() ? createPeekForTooltip(ex) : customizeExpressionTreeAudit(ex).trim())
+                                + "\nNotes:\n"
+                                + (ex.getNotes().equals("") ? "none" : ex.getNotes()));
                         if (!ex.amHealthy()) {
                             tooltip.setGraphic(imageView);
                         }
@@ -2842,7 +2847,7 @@ public class ExpressionBuilderController implements Initializable {
     /**
      * Creates a new expression from the modifications.
      *
-     * @param expressionName   the value of expressionName
+     * @param expressionName the value of expressionName
      * @param expressionString the value of expressionString
      */
     private Expression makeExpression(String expressionName, final String expressionString) {
@@ -2917,7 +2922,7 @@ public class ExpressionBuilderController implements Initializable {
         // first detect if user should have used SummaryCalculation choice
         OperationOrFunctionInterface operation = ((ExpressionTreeBuilderInterface) exp.getExpressionTree()).getOperation();
         if ((operation.isSummaryCalc()
-                ||(operation instanceof Value))
+                || (operation instanceof Value))
                 && !summaryCalculationSwitchCheckBox.isSelected()) {
             Alert alert = new Alert(Alert.AlertType.WARNING,
                     "Squid recommends choosing the Summary Calculation switch ... make it so?",
@@ -3595,10 +3600,10 @@ public class ExpressionBuilderController implements Initializable {
                         setText(operationOrFunction);
                         Tooltip t
                                 = createFloatingTooltip(getText()
-                                .replaceAll("(:.*|\\(.*\\))$", "").trim()
-                                .replaceAll("Tab", VISIBLETABPLACEHOLDER)
-                                .replaceAll("New line", VISIBLENEWLINEPLACEHOLDER)
-                                .replaceAll("White space", VISIBLEWHITESPACEPLACEHOLDER));
+                                        .replaceAll("(:.*|\\(.*\\))$", "").trim()
+                                        .replaceAll("Tab", VISIBLETABPLACEHOLDER)
+                                        .replaceAll("New line", VISIBLENEWLINEPLACEHOLDER)
+                                        .replaceAll("White space", VISIBLEWHITESPACEPLACEHOLDER));
                         setOnMouseEntered((event) -> {
                             showToolTip(event, this, t);
                         });

--- a/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/expressions/ExpressionBuilderController.java
@@ -1608,21 +1608,23 @@ public class ExpressionBuilderController implements Initializable {
         // Squid Functions ======================================================
         List<String> squidFunctionStrings = new ArrayList<>();
         for (Map.Entry<String, String> op : SQUID_FUNCTIONS_MAP.entrySet()) {
-            int argumentCount = Function.operationFactory(op.getValue()).getArgumentCount();
-            String[] inputLabels = Function.operationFactory(op.getValue()).getLabelsForInputValues();
-            StringBuilder args = new StringBuilder();
-            args.append(op.getKey()).append("(");
-            for (int i = 0; i < argumentCount; i++) {
-                if ((inputLabels.length > i)  &&   inputLabels[i].indexOf("default") > 0) {
-                    String[] defaultValue = inputLabels[i].split("=");
-                    args.append(defaultValue[1].trim());
-                } else {
-                    args.append("Arg").append(i);
+            if (!ALIASED_FUNCTIONS_MAP.containsKey(op.getKey())) {
+                int argumentCount = Function.operationFactory(op.getValue()).getArgumentCount();
+                String[] inputLabels = Function.operationFactory(op.getValue()).getLabelsForInputValues();
+                StringBuilder args = new StringBuilder();
+                args.append(op.getKey()).append("(");
+                for (int i = 0; i < argumentCount; i++) {
+                    if ((inputLabels.length > i) && inputLabels[i].indexOf("default") > 0) {
+                        String[] defaultValue = inputLabels[i].split("=");
+                        args.append(defaultValue[1].trim());
+                    } else {
+                        args.append("Arg").append(i);
+                    }
+                    args.append(i < (argumentCount - 1) ? "," : ")");
                 }
-                args.append(i < (argumentCount - 1) ? "," : ")");
-            }
 
-            squidFunctionStrings.add(args.toString());
+                squidFunctionStrings.add(args.toString());
+            }
         }
 
         items = FXCollections.observableArrayList(squidFunctionStrings);

--- a/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/SquidUIController.fxml
@@ -123,7 +123,7 @@
                                     <items>
                                         <MenuItem disable="true" mnemonicParsing="false" text="Specify Reports Layout" />
                                         <MenuItem mnemonicParsing="false" onAction="#unknownsReportTableAction" text="Report Table - per Squid 2.*" />
-                                        <MenuItem mnemonicParsing="false" onAction="#unknownsBySampleReportTableAction" text="Report Table - by Sample for ET_Redux" />
+                                        <MenuItem mnemonicParsing="false" onAction="#unknownsBySampleReportTableAction" text="Report Table - by Sample for use by ET_Redux and Topsoil" />
                                         <MenuItem mnemonicParsing="false" onAction="#openSquid3ReportTableUnknowns" text="Report Table - per Squid 3" />
                                     </items>
                                 </Menu>

--- a/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
@@ -65,14 +65,19 @@
                               <ListView fx:id="builtInExpressionsListView" />
                            </content>
                         </TitledPane>
-                        <TitledPane fx:id="ratioExpressionsTitledPane" animated="false" style="-fx-font-family: SansSerif; -fx-font-size: 12; -fx-font-weight: bold;" text="Ratios with Uncertainties">
+                        <TitledPane animated="false" style="-fx-font-family: SansSerif; -fx-font-size: 12; -fx-font-weight: bold;" text="Ratios with Uncertainties">
                            <content>
                               <ListView fx:id="ratioExpressionsListView" />
                            </content>
                         </TitledPane>
-                        <TitledPane fx:id="isotopeExpressionsTitledPane" animated="false" layoutX="10.0" layoutY="79.0" style="-fx-font-family: SansSerif; -fx-font-size: 12; -fx-font-weight: bold;" text="Isotopes (Species)">
+                        <TitledPane animated="false" layoutX="10.0" layoutY="79.0" style="-fx-font-family: SansSerif; -fx-font-size: 12; -fx-font-weight: bold;" text="Isotopes (Species)">
                            <content>
                               <ListView fx:id="isotopesExpressionsListView" />
+                           </content>
+                        </TitledPane>
+                        <TitledPane animated="false" layoutX="10.0" layoutY="102.0" style="-fx-font-family: SansSerif; -fx-font-size: 12; -fx-font-weight: bold;" text="Spot Metadata Fields">
+                           <content>
+                              <ListView fx:id="spotMetaDataExpressionsListView" />
                            </content>
                         </TitledPane>
                         <TitledPane fx:id="referenceMaterialsTitledPane" animated="false" expanded="false" prefHeight="324.0" prefWidth="265.0" style="-fx-font-size: 12; -fx-font-family: SansSerif; -fx-font-weight: bold;" text="Reference Material Values (see Task Mgr)">
@@ -109,7 +114,7 @@
                   </HBox>
                   <Accordion fx:id="othersAccordion" nodeOrientation="LEFT_TO_RIGHT">
                      <panes>
-                        <TitledPane fx:id="constantsTitledPane" animated="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Constants and Numbers">
+                        <TitledPane animated="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Constants and Numbers">
                            <content>
                               <ListView fx:id="constantsListView" />
                            </content>
@@ -119,7 +124,7 @@
                               <ListView fx:id="operationsListView" />
                            </content>
                         </TitledPane>
-                        <TitledPane fx:id="mathFunctionsTitledPane" animated="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Math Functions">
+                        <TitledPane animated="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Math Functions">
                            <content>
                               <ListView fx:id="mathFunctionsListView" />
                            </content>
@@ -134,12 +139,12 @@
                               <ListView fx:id="squidFunctionsListView" />
                            </content>
                         </TitledPane>
-                        <TitledPane fx:id="logicFunctionsTitledPane" animated="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Logic Functions">
+                        <TitledPane animated="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Logic Functions">
                            <content>
                               <ListView fx:id="logicFunctionsListView" />
                            </content>
                         </TitledPane>
-                        <TitledPane fx:id="presentationTitledPane" animated="false" layoutX="10.0" layoutY="172.0" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Presentation">
+                        <TitledPane animated="false" layoutX="10.0" layoutY="172.0" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Presentation">
                            <content>
                               <ListView fx:id="presentationListView" />
                            </content>

--- a/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
+++ b/squidApp/src/main/resources/org/cirdles/squid/gui/expressions/ExpressionBuilder.fxml
@@ -70,6 +70,11 @@
                               <ListView fx:id="ratioExpressionsListView" />
                            </content>
                         </TitledPane>
+                        <TitledPane fx:id="isotopeExpressionsTitledPane" animated="false" layoutX="10.0" layoutY="79.0" style="-fx-font-family: SansSerif; -fx-font-size: 12; -fx-font-weight: bold;" text="Isotopes (Species)">
+                           <content>
+                              <ListView fx:id="isotopesExpressionsListView" />
+                           </content>
+                        </TitledPane>
                         <TitledPane fx:id="referenceMaterialsTitledPane" animated="false" expanded="false" prefHeight="324.0" prefWidth="265.0" style="-fx-font-size: 12; -fx-font-family: SansSerif; -fx-font-weight: bold;" text="Reference Material Values (see Task Mgr)">
                            <content>
                               <ListView fx:id="referenceMaterialsListView" />
@@ -119,7 +124,12 @@
                               <ListView fx:id="mathFunctionsListView" />
                            </content>
                         </TitledPane>
-                        <TitledPane fx:id="squidFunctionsTitledPane" animated="false" expanded="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Squid Functions">
+                        <TitledPane animated="false" expanded="false" layoutX="10.0" layoutY="79.0" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Squid Functions - Common">
+                           <content>
+                              <ListView fx:id="squidFunctionsCommonListView" />
+                           </content>
+                        </TitledPane>
+                        <TitledPane animated="false" expanded="false" style="-fx-font-family: SansSerif; -fx-font-weight: bold; -fx-font-size: 12;" text="Squid Functions - Other">
                            <content>
                               <ListView fx:id="squidFunctionsListView" />
                            </content>

--- a/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
+++ b/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
@@ -131,6 +131,7 @@ FUNCTION :
     S Q B I W E I G H T |
     B I W E I G H T |
     S Q W T D A V |
+    W T D A V |
     T O T A L C P S |
     L O O K U P |
     M A X |

--- a/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
+++ b/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
@@ -133,7 +133,6 @@ FUNCTION :
     S Q W T D A V |
     W T D A V |
     T O T A L C P S |
-    L O O K U P |
     M A X |
     M I N |
     A B S |

--- a/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
+++ b/squidCore/src/main/antlr/org/cirdles/squid/ExpressionsForSquid2.g4
@@ -129,6 +129,7 @@ FUNCTION :
     S Q R T |
     R O B R E G |
     S Q B I W E I G H T |
+    B I W E I G H T |
     S Q W T D A V |
     T O T A L C P S |
     L O O K U P |

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/Task.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/Task.java
@@ -62,6 +62,8 @@ import org.cirdles.squid.shrimp.SquidSpeciesModel;
 import org.cirdles.squid.tasks.evaluationEngines.ExpressionEvaluator;
 import org.cirdles.squid.tasks.evaluationEngines.TaskExpressionEvaluatedPerSpotPerScanModelInterface;
 import org.cirdles.squid.tasks.expressions.Expression;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.AV_PARENT_ELEMENT_CONC_CONST;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.CORR_8_PRIMARY_CALIB_CONST_DELTA_PCT;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.OVER_COUNTS_PERSEC_4_8;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.OVER_COUNT_4_6_8;
 import org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory;
@@ -105,7 +107,6 @@ import org.cirdles.squid.utilities.fileUtilities.PrawnFileUtilities;
 import org.cirdles.squid.utilities.stateUtilities.SquidPersistentState;
 import org.cirdles.squid.tasks.taskDesign.TaskDesign;
 import org.cirdles.squid.utilities.xmlSerialization.XMLSerializerInterface;
-import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.AV_PARENT_ELEMENT_CONC_CONST;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TH_CONCEN_PPM_RM;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TH_U_EXP;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TH_U_EXP_RM;
@@ -113,11 +114,12 @@ import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpr
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TOTAL_208_232_RM;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TOTAL_206_238;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TOTAL_208_232;
-import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.CORR_8_PRIMARY_CALIB_CONST_DELTA_PCT;
-import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.U_CONCEN_PPM_RM;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.DEFAULT_BACKGROUND_MASS_LABEL;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.MIN_206PB238U_EXT_1SIGMA_ERR_PCT;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.MIN_208PB232TH_EXT_1SIGMA_ERR_PCT;
-import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.DEFAULT_BACKGROUND_MASS_LABEL;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.U_CONCEN_PPM_RM;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.OVER_COUNTS_PERSEC_4_8;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.OVER_COUNT_4_6_8;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.PARENT_ELEMENT_CONC_CONST;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.PB4COR206_238CALIB_CONST_WM;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.PB4COR208_232CALIB_CONST_WM;
@@ -126,7 +128,30 @@ import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpr
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.PB8COR206_238CALIB_CONST_WM;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.REQUIRED_NOMINAL_MASSES;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.REQUIRED_RATIO_NAMES;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TH_CONCEN_PPM_RM;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TH_U_EXP;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TH_U_EXP_RM;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TOTAL_206_238;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TOTAL_206_238_RM;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TOTAL_208_232;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.TOTAL_208_232_RM;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.U_CONCEN_PPM_RM;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.generateExperimentalExpressions;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.generateOverCountExpressions;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.generatePerSpotProportionsOfCommonPb;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.generatePlaceholderExpressions;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.generatePpmUandPpmTh;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.overCountMeans;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.samRadiogenicCols;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.stdRadiogenicCols;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.updateCommonLeadParameterValuesFromModel;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.updateConcReferenceMaterialValuesFromModel;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.updatePhysicalConstantsParameterValuesFromModel;
+import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsFactory.updateReferenceMaterialValuesFromModel;
+import static org.cirdles.squid.tasks.expressions.constants.ConstantNode.MISSING_EXPRESSION_STRING;
 import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeBuilderInterface;
+import static org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeInterface.convertObjectArrayToDoubles;
+import static org.cirdles.squid.utilities.conversionUtilities.CloningUtilities.clone2dArray;
 import org.cirdles.squid.utilities.stateUtilities.SquidLabData;
 
 /**
@@ -1140,7 +1165,7 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
         } else {
             namedExpressionsMap.put(exp.getName(), exp.getExpressionTree());
             buildExpressionDependencyGraphs();
-            evaluateTaskExpression(exp);
+            evaluateTaskExpression(exp.getExpressionTree());
             List<String> evaluated = new ArrayList<>();
             evaluated.add(exp.getName());
             evaluateDependentExpressions(evaluated, exp.getName());
@@ -1153,7 +1178,7 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
             for (String providedToName : providedTo) {
                 if (!evaluated.contains(providedToName)) {
                     evaluated.add(providedToName);
-                    evaluateTaskExpression(getExpressionByName(providedToName));
+                    evaluateTaskExpression(getExpressionByName(providedToName).getExpressionTree());
                     evaluateDependentExpressions(evaluated, providedToName);
                 }
             }
@@ -1700,12 +1725,15 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
         });
 
         for (Expression expression : taskExpressionsOrdered) {
-            evaluateTaskExpression(expression);
+            evaluateTaskExpression(expression.getExpressionTree());
         }
     }
 
-    public void evaluateTaskExpression(Expression expression) {
-        ExpressionTreeInterface expressionTree = expression.getExpressionTree();
+    /**
+     *
+     * @param expressionTree the value of expressionTree2
+     */
+    public void evaluateTaskExpression(ExpressionTreeInterface expressionTree) {
 
         if (expressionTree.amHealthy()) {// && expressionTree.isRootExpressionTree()) {
             // determine subset of spots to be evaluated - default = all
@@ -1727,24 +1755,16 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
             }
             // now evaluate expressionTree
             try {
-                evaluateExpressionForSpotSet(expression, spotsForExpression);
+                evaluateExpressionForSpotSet(expressionTree, spotsForExpression);
             } catch (SquidException | ArrayIndexOutOfBoundsException squidException) {
-                //System.out.println("Out of bounds at evaluateTaskExpressions");
+
             }
         }
     }
 
-    /**
-     *
-     * @param expressionTree
-     * @param spotsForExpression
-     * @throws SquidException
-     */
     private void evaluateExpressionForSpotSet(
-            Expression expression,
+            ExpressionTreeInterface expressionTree, 
             List<ShrimpFractionExpressionInterface> spotsForExpression) throws SquidException {
-
-        ExpressionTreeInterface expressionTree = expression.getExpressionTree();
 
         // determine taskType of expressionTree
         // Summary expression test
@@ -1754,11 +1774,11 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
 
             // May 2018 new logic to support user rejecting some fractions in summary calculations - Weighted Mean for now
             SpotSummaryDetails spotSummaryDetails;
-            if (taskExpressionsEvaluationsPerSpotSet.containsKey(expression.getName())) {
-                spotSummaryDetails = taskExpressionsEvaluationsPerSpotSet.get(expression.getName());
+            if (taskExpressionsEvaluationsPerSpotSet.containsKey(expressionTree.getName())) {
+                spotSummaryDetails = taskExpressionsEvaluationsPerSpotSet.get(expressionTree.getName());
             } else {
                 spotSummaryDetails = new SpotSummaryDetails(expressionTree);
-                taskExpressionsEvaluationsPerSpotSet.put(expression.getName(), spotSummaryDetails);
+                taskExpressionsEvaluationsPerSpotSet.put(expressionTree.getName(), spotSummaryDetails);
             }
 
             // if the spotsForExpression are the same, then preserve list of indices of rejected
@@ -1832,14 +1852,14 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
     }
 
     private void evaluateExpressionForSpot(
-            ExpressionTreeInterface expression,
+            ExpressionTreeInterface expressionTree,
             ShrimpFractionExpressionInterface spot) throws SquidException {
 
-        if (((ExpressionTree) expression).hasRatiosOfInterest()) {
+        if (((ExpressionTree) expressionTree).hasRatiosOfInterest()) {
             // case of Squid switch "NU"
             ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator();
             TaskExpressionEvaluatedPerSpotPerScanModelInterface taskExpressionEvaluatedPerSpotPerScanModel
-                    = expressionEvaluator.evaluateTaskExpressionsPerSpotPerScan(this, expression, spot);
+                    = expressionEvaluator.evaluateTaskExpressionsPerSpotPerScan(this, expressionTree, spot);
 
             // save scan-specific results
             List<TaskExpressionEvaluatedPerSpotPerScanModelInterface> taskExpressionsForScansEvaluated = spot.getTaskExpressionsForScansEvaluated();
@@ -1853,17 +1873,17 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
                 taskExpressionEvaluatedPerSpotPerScanModel.getRatioFractErr()}};
 
             Map<ExpressionTreeInterface, double[][]> taskExpressionsPerSpot = spot.getTaskExpressionsEvaluationsPerSpot();
-            if (taskExpressionsPerSpot.containsKey(expression)) {
-                taskExpressionsPerSpot.remove(expression);
+            if (taskExpressionsPerSpot.containsKey(expressionTree)) {
+                taskExpressionsPerSpot.remove(expressionTree);
             }
-            spot.getTaskExpressionsEvaluationsPerSpot().put(expression, value);
+            spot.getTaskExpressionsEvaluationsPerSpot().put(expressionTree, value);
 
         } else {
             List<ShrimpFractionExpressionInterface> singleSpot = new ArrayList<>();
             singleSpot.add(spot);
             try {
-                double[][] value = convertObjectArrayToDoubles(expression.eval(singleSpot, this));
-                spot.getTaskExpressionsEvaluationsPerSpot().put(expression, value);
+                double[][] value = convertObjectArrayToDoubles(expressionTree.eval(singleSpot, this));
+                spot.getTaskExpressionsEvaluationsPerSpot().put(expressionTree, value);
             } catch (SquidException squidException) {
 //                //System.out.println(squidException.getMessage() + " while processing " + expressionTree.getName());
             }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/Expression.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/Expression.java
@@ -267,9 +267,10 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
             auditReport
                     += "Target Spots: "
                     + (String) ((match == -1) ? "MISSING - Please select" : ((match == 1))
-                                    ? "NOT MATCHED" : "MATCHED");
+                                    ? "NOT MATCHED" : "MATCHED")
+                    + "\n";
             if (targetAudit.size() > 0) {
-                auditReport += "\nTarget Spots Audit:\n";
+                auditReport += "Target Spots Audit:\n";
                 for (String audit : targetAudit) {
                     auditReport += audit + "\n";
                 }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/Expression.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/Expression.java
@@ -46,11 +46,10 @@ import org.cirdles.squid.tasks.expressions.variables.VariableNodeForSummaryXMLCo
 import org.cirdles.squid.utilities.xmlSerialization.XMLSerializerInterface;
 import static org.cirdles.squid.constants.Squid3Constants.SUPERSCRIPT_SPACE;
 import static org.cirdles.squid.constants.Squid3Constants.SpotTypes.UNKNOWN;
-import org.cirdles.squid.tasks.Task;
-import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsAliased.BUILTIN_EXPRESSION_ALIASEDNAMES;
 import org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsNotes;
 import org.cirdles.squid.tasks.expressions.expressionTrees.BuiltInExpressionInterface;
 import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeParsedFromExcelString;
+import static org.cirdles.squid.tasks.expressions.functions.Function.replaceAliasedFunctionNamesInExpressionString;
 
 /**
  *
@@ -223,7 +222,7 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
      * @param expressionName the value of expressionName
      * @param expressionString the value of expressionString
      * @param namedExpressionsMap the value of namedExpressionsMap
-     * @return 
+     * @return
      */
     public static Expression makeExpressionForAudit(
             String expressionName, final String expressionString, Map<String, ExpressionTreeInterface> namedExpressionsMap) {
@@ -276,7 +275,7 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
                 }
                 auditReport += "\n";
             }
-            
+
             auditReport
                     += "Expression healthy: "
                     + String.valueOf(expressionTree.amHealthy()).toUpperCase(Locale.ENGLISH);
@@ -400,6 +399,7 @@ public class Expression implements Comparable<Expression>, XMLSerializerInterfac
      * @return the excelExpressionString
      */
     public String getExcelExpressionString() {
+        excelExpressionString = replaceAliasedFunctionNamesInExpressionString(excelExpressionString);
         return excelExpressionString;
     }
 

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/AgePb76.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/AgePb76.java
@@ -36,7 +36,7 @@ public class AgePb76 extends Function {
     private static final long serialVersionUID = -6711265919551953531L;
 
     /**
-     * Provides the functionality of Squid's agePb76 by calling pbPbAge and
+     * Provides the functionality of Squid2.5's agePb76 by calling pbPbAge and
      * returning "Age" and "AgeErr" and encoding the labels for each cell of the
      * values array produced by eval.
      *

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/AgePb76WithErr.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/AgePb76WithErr.java
@@ -36,7 +36,7 @@ public class AgePb76WithErr extends Function {
     private static final long serialVersionUID = 1356960783530914047L;
 
     /**
-     * Provides the functionality of Squid's agePb76 by calling pbPbAge and
+     * Provides the functionality of Squid2.5's agePb76 by calling pbPbAge and
      * returning "Age" and "AgeErr" and encoding the labels for each cell of the
      * values array produced by eval.
      *

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/CalculateMeanConcStd.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/CalculateMeanConcStd.java
@@ -42,13 +42,13 @@ public class CalculateMeanConcStd extends Function {
      * https://github.com/CIRDLES/ET_Redux/wiki/SQ2.50-Procedural-Framework:-Part-1
      */
     public CalculateMeanConcStd() {
-        name = "calculateMeanConcStd";
+        name = "CalculateMeanConcStd";
         argumentCount = 1;
         precedence = 4;
         rowCount = 1;
         colCount = 2;
         labelsForOutputValues = new String[][]{{AV_PARENT_ELEMENT_CONC_CONST}};
-        labelsForInputValues = new String[]{"numbers"};
+        labelsForInputValues = new String[]{"per-spot expression with concentration values in ppm"};
         summaryCalc = true;
         definition = "Calculates the sum divided by the count, ignoring tiny values < 1.0E-30.";
     }
@@ -102,7 +102,7 @@ public class CalculateMeanConcStd extends Function {
     public String toStringMathML(List<ExpressionTreeInterface> childrenET) {
         String retVal
                 = "<mrow>"
-                + "<mi>CalculateMeanConcStd</mi>"
+                + "<mi>" + name + "</mi>"
                 + "<mfenced>";
 
         retVal += buildChildrenToMathML(childrenET);

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Concordia.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Concordia.java
@@ -36,7 +36,7 @@ public class Concordia extends Function {
     private static final long serialVersionUID = 4127169946137305310L;
 
     /**
-     * Provides the functionality of Squid's agePb76 by calling pbPbAge and
+     * Provides the functionality of Squid2.5's agePb76 by calling pbPbAge and
      * returning "Age" and "AgeErr" and encoding the labels for each cell of the
      * values array produced by eval.
      *
@@ -46,13 +46,13 @@ public class Concordia extends Function {
      * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/UPb.bas
      */
     public Concordia() {
-        name = "concordia";
+        name = "Concordia";
         argumentCount = 3;
         precedence = 4;
         rowCount = 1;
         colCount = 4;
         labelsForOutputValues = new String[][]{{"Age", "1\u03C3 abs", "MSWD", "Prob Of MSWD"}};
-        labelsForInputValues = new String[]{"ratioXAnd1\u03C3 abs", "ratioYAnd1\u03C3 abs", "rho"};
+        labelsForInputValues = new String[]{"ratioX with 1\u03C3 abs", "ratioY with 1\u03C3 abs", "rho"};
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/ConcordiaTW.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/ConcordiaTW.java
@@ -37,7 +37,7 @@ public class ConcordiaTW extends Function {
     private static final long serialVersionUID = -1637184737851510733L;
 
     /**
-     * Provides the functionality of Squid's agePb76 by calling pbPbAge and
+     * Provides the functionality of Squid2.5's agePb76 by calling pbPbAge and
      * returning "Age" and "AgeErr" and encoding the labels for each cell of the
      * values array produced by eval.
      *
@@ -47,13 +47,13 @@ public class ConcordiaTW extends Function {
      * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/UPb.bas
      */
     public ConcordiaTW() {
-        name = "concordiaTW";
+        name = "ConcordiaTW";
         argumentCount = 2;
         precedence = 4;
         rowCount = 1;
         colCount = 4;
         labelsForOutputValues = new String[][]{{"Raw Conc Age", "1\u03C3 abs", "MSWD Conc", "Prob Conc"}};
-        labelsForInputValues = new String[]{"ratioXAnd1\u03C3 abs", "ratioYAnd1\u03C3 abs"};
+        labelsForInputValues = new String[]{"ratioX with 1\u03C3 abs", "ratioY with 1\u03C3 abs"};
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Count.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Count.java
@@ -37,13 +37,13 @@ public class Count extends Function {
      *
      */
     public Count() {
-        name = "count";
+        name = "Count";
         argumentCount = 1;
         precedence = 4;
         rowCount = 1;
         colCount = 2;
         labelsForOutputValues = new String[][]{{"count"}};
-        labelsForInputValues = new String[]{"numbers"};
+        labelsForInputValues = new String[]{"per-spot expression"};
         summaryCalc = true;
         definition = "Returns a count of spots targeted by the expression.";
     }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
@@ -96,30 +96,31 @@ public abstract class Function
     static {
 
         // key is case-insensitive name and value is case-sensitive method name
-        SQUID_FUNCTIONS_MAP.put("agePb76", "agePb76");
-        SQUID_FUNCTIONS_MAP.put("agePb76WithErr", "agePb76WithErr");
-        SQUID_FUNCTIONS_MAP.put("age7corrWithErr", "age7corrWithErr");
-        SQUID_FUNCTIONS_MAP.put("age8corrWithErr", "age8corrWithErr");
-        SQUID_FUNCTIONS_MAP.put("age7CorrPb8Th2WithErr", "age7CorrPb8Th2WithErr");
-        SQUID_FUNCTIONS_MAP.put("rad8corPb7U5WithErr", "rad8corPb7U5WithErr");
-        SQUID_FUNCTIONS_MAP.put("rad8corConcRho", "rad8corConcRho");
-        SQUID_FUNCTIONS_MAP.put("pb76", "pb76");
-        SQUID_FUNCTIONS_MAP.put("pb46cor7", "pb46cor7");
-        SQUID_FUNCTIONS_MAP.put("pb46cor8", "pb46cor8");
-        SQUID_FUNCTIONS_MAP.put("pb206U238rad", "pb206U238rad");
-        SQUID_FUNCTIONS_MAP.put("calculateMeanConcStd", "calculateMeanConcStd");
-        SQUID_FUNCTIONS_MAP.put("stdPb86radCor7per", "stdPb86radCor7per");
-        SQUID_FUNCTIONS_MAP.put("pb86radCor7per", "pb86radCor7per");
-        SQUID_FUNCTIONS_MAP.put("concordiaTW", "concordiaTW");
-        SQUID_FUNCTIONS_MAP.put("concordia", "concordia");
-        SQUID_FUNCTIONS_MAP.put("robReg", "robReg");
-        SQUID_FUNCTIONS_MAP.put("sqBiweight", "sqBiweight");
+        SQUID_FUNCTIONS_MAP.put("AgePb76", "agePb76");
+        SQUID_FUNCTIONS_MAP.put("AgePb76WithErr", "agePb76WithErr");
+        SQUID_FUNCTIONS_MAP.put("Age7corrWithErr", "age7corrWithErr");
+        SQUID_FUNCTIONS_MAP.put("Age8corrWithErr", "age8corrWithErr");
+        SQUID_FUNCTIONS_MAP.put("Age7CorrPb8Th2WithErr", "age7CorrPb8Th2WithErr");
+        SQUID_FUNCTIONS_MAP.put("Rad8corPb7U5WithErr", "rad8corPb7U5WithErr");
+        SQUID_FUNCTIONS_MAP.put("Rad8corConcRho", "rad8corConcRho");
+        SQUID_FUNCTIONS_MAP.put("Pb76", "pb76");
+        SQUID_FUNCTIONS_MAP.put("Pb46cor7", "pb46cor7");
+        SQUID_FUNCTIONS_MAP.put("Pb46cor8", "pb46cor8");
+        SQUID_FUNCTIONS_MAP.put("Pb206U238rad", "pb206U238rad");
+        SQUID_FUNCTIONS_MAP.put("CalculateMeanConcStd", "calculateMeanConcStd");
+        SQUID_FUNCTIONS_MAP.put("StdPb86radCor7per", "stdPb86radCor7per");
+        SQUID_FUNCTIONS_MAP.put("Pb86radCor7per", "pb86radCor7per");
+        SQUID_FUNCTIONS_MAP.put("ConcordiaTW", "concordiaTW");
+        SQUID_FUNCTIONS_MAP.put("Concordia", "concordia");
+        SQUID_FUNCTIONS_MAP.put("RobReg", "robReg");
+        SQUID_FUNCTIONS_MAP.put("SqBiweight", "sqBiweight");
         SQUID_FUNCTIONS_MAP.put("Biweight", "sqBiweight");
-        SQUID_FUNCTIONS_MAP.put("sqWtdAv", "sqWtdAv");
+        SQUID_FUNCTIONS_MAP.put("SqWtdAv", "sqWtdAv");
+        SQUID_FUNCTIONS_MAP.put("WtdAv", "sqWtdAv");
         SQUID_FUNCTIONS_MAP.put("TotalCps", "totalCps");
 //        SQUID_FUNCTIONS_MAP.put("lookup", "lookup");
         SQUID_FUNCTIONS_MAP.put("WtdMeanACalc", "wtdMeanACalc");
-        SQUID_FUNCTIONS_MAP.put("valueModel", "valueModel");
+        SQUID_FUNCTIONS_MAP.put("ValueModel", "valueModel");
 
         LOGIC_FUNCTIONS_MAP.put("and", "and");
         LOGIC_FUNCTIONS_MAP.put("if", "sqIf");
@@ -138,7 +139,8 @@ public abstract class Function
         FUNCTIONS_MAP.putAll(SQUID_FUNCTIONS_MAP);
         FUNCTIONS_MAP.putAll(LOGIC_FUNCTIONS_MAP);
 
-        ALIASED_FUNCTIONS_MAP.put("sqBiweight", "Biweight");
+        ALIASED_FUNCTIONS_MAP.put("SqBiweight", "Biweight");
+        ALIASED_FUNCTIONS_MAP.put("SqWtdAv", "WtdAv");
 
     }
 
@@ -154,7 +156,7 @@ public abstract class Function
                 retVal = retVal.replaceAll(entry.getKey(), entry.getValue());
             }
         }
-        
+
         return retVal;
     }
 
@@ -213,6 +215,22 @@ public abstract class Function
      */
     public static OperationOrFunctionInterface biweight() {
         return new SqBiweight();
+    }
+
+    /**
+     *
+     * @return
+     */
+    public static OperationOrFunctionInterface sqWtdAv() {
+        return new SqWtdAv();
+    }
+
+    /**
+     *
+     * @return
+     */
+    public static OperationOrFunctionInterface wtdAv() {
+        return new SqWtdAv();
     }
 
     /**
@@ -317,14 +335,6 @@ public abstract class Function
      */
     public static OperationOrFunctionInterface pb86radCor7per() {
         return new Pb86radCor7per();
-    }
-
-    /**
-     *
-     * @return
-     */
-    public static OperationOrFunctionInterface sqWtdAv() {
-        return new SqWtdAv();
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
 import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeInterface;
 import org.cirdles.squid.tasks.expressions.OperationOrFunctionInterface;
@@ -90,8 +91,11 @@ public abstract class Function
     public static final Map<String, String> SQUID_FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     public static final Map<String, String> LOGIC_FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
+    public static final Map<String, String> ALIASED_FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
     static {
 
+        // key is case-insensitive name and value is case-sensitive method name
         SQUID_FUNCTIONS_MAP.put("agePb76", "agePb76");
         SQUID_FUNCTIONS_MAP.put("agePb76WithErr", "agePb76WithErr");
         SQUID_FUNCTIONS_MAP.put("age7corrWithErr", "age7corrWithErr");
@@ -110,6 +114,7 @@ public abstract class Function
         SQUID_FUNCTIONS_MAP.put("concordia", "concordia");
         SQUID_FUNCTIONS_MAP.put("robReg", "robReg");
         SQUID_FUNCTIONS_MAP.put("sqBiweight", "sqBiweight");
+        SQUID_FUNCTIONS_MAP.put("Biweight", "sqBiweight");
         SQUID_FUNCTIONS_MAP.put("sqWtdAv", "sqWtdAv");
         SQUID_FUNCTIONS_MAP.put("TotalCps", "totalCps");
 //        SQUID_FUNCTIONS_MAP.put("lookup", "lookup");
@@ -133,10 +138,24 @@ public abstract class Function
         FUNCTIONS_MAP.putAll(SQUID_FUNCTIONS_MAP);
         FUNCTIONS_MAP.putAll(LOGIC_FUNCTIONS_MAP);
 
+        ALIASED_FUNCTIONS_MAP.put("sqBiweight", "Biweight");
+
     }
 
     public Function() {
         this.definition = "todo";
+    }
+
+    public static String replaceAliasedFunctionNamesInExpressionString(String excelExpressionString) {
+        String retVal = excelExpressionString;
+        for (Entry<String, String> entry : ALIASED_FUNCTIONS_MAP.entrySet()) {
+            if (retVal != null && retVal.matches(".*(?i)" + entry.getKey() + "(.*)")) {
+                // replace alias
+                retVal = retVal.replaceAll(entry.getKey(), entry.getValue());
+            }
+        }
+        
+        return retVal;
     }
 
     /**
@@ -185,6 +204,14 @@ public abstract class Function
      * @return
      */
     public static OperationOrFunctionInterface sqBiweight() {
+        return new SqBiweight();
+    }
+
+    /**
+     *
+     * @return
+     */
+    public static OperationOrFunctionInterface biweight() {
         return new SqBiweight();
     }
 

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Function.java
@@ -88,6 +88,7 @@ public abstract class Function
     public static final Map<String, String> FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     public static final Map<String, String> MATH_FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    public static final Map<String, String> SQUID_COMMMON_FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     public static final Map<String, String> SQUID_FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     public static final Map<String, String> LOGIC_FUNCTIONS_MAP = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
@@ -96,31 +97,32 @@ public abstract class Function
     static {
 
         // key is case-insensitive name and value is case-sensitive method name
-        SQUID_FUNCTIONS_MAP.put("AgePb76", "agePb76");
-        SQUID_FUNCTIONS_MAP.put("AgePb76WithErr", "agePb76WithErr");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("AgePb76", "agePb76");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("AgePb76WithErr", "agePb76WithErr");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("Pb76", "pb76");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("Pb206U238rad", "pb206U238rad");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("ConcordiaTW", "concordiaTW");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("Concordia", "concordia");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("RobReg", "robReg");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("SqBiweight", "sqBiweight");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("Biweight", "sqBiweight");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("SqWtdAv", "sqWtdAv");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("WtdAv", "sqWtdAv");
+        SQUID_COMMMON_FUNCTIONS_MAP.put("ValueModel", "valueModel");
+
         SQUID_FUNCTIONS_MAP.put("Age7corrWithErr", "age7corrWithErr");
         SQUID_FUNCTIONS_MAP.put("Age8corrWithErr", "age8corrWithErr");
         SQUID_FUNCTIONS_MAP.put("Age7CorrPb8Th2WithErr", "age7CorrPb8Th2WithErr");
         SQUID_FUNCTIONS_MAP.put("Rad8corPb7U5WithErr", "rad8corPb7U5WithErr");
         SQUID_FUNCTIONS_MAP.put("Rad8corConcRho", "rad8corConcRho");
-        SQUID_FUNCTIONS_MAP.put("Pb76", "pb76");
         SQUID_FUNCTIONS_MAP.put("Pb46cor7", "pb46cor7");
         SQUID_FUNCTIONS_MAP.put("Pb46cor8", "pb46cor8");
-        SQUID_FUNCTIONS_MAP.put("Pb206U238rad", "pb206U238rad");
         SQUID_FUNCTIONS_MAP.put("CalculateMeanConcStd", "calculateMeanConcStd");
         SQUID_FUNCTIONS_MAP.put("StdPb86radCor7per", "stdPb86radCor7per");
         SQUID_FUNCTIONS_MAP.put("Pb86radCor7per", "pb86radCor7per");
-        SQUID_FUNCTIONS_MAP.put("ConcordiaTW", "concordiaTW");
-        SQUID_FUNCTIONS_MAP.put("Concordia", "concordia");
-        SQUID_FUNCTIONS_MAP.put("RobReg", "robReg");
-        SQUID_FUNCTIONS_MAP.put("SqBiweight", "sqBiweight");
-        SQUID_FUNCTIONS_MAP.put("Biweight", "sqBiweight");
-        SQUID_FUNCTIONS_MAP.put("SqWtdAv", "sqWtdAv");
-        SQUID_FUNCTIONS_MAP.put("WtdAv", "sqWtdAv");
         SQUID_FUNCTIONS_MAP.put("TotalCps", "totalCps");
 //        SQUID_FUNCTIONS_MAP.put("lookup", "lookup");
         SQUID_FUNCTIONS_MAP.put("WtdMeanACalc", "wtdMeanACalc");
-        SQUID_FUNCTIONS_MAP.put("ValueModel", "valueModel");
 
         LOGIC_FUNCTIONS_MAP.put("and", "and");
         LOGIC_FUNCTIONS_MAP.put("if", "sqIf");
@@ -136,11 +138,13 @@ public abstract class Function
         MATH_FUNCTIONS_MAP.put("count", "count");
 
         FUNCTIONS_MAP.putAll(MATH_FUNCTIONS_MAP);
+        FUNCTIONS_MAP.putAll(SQUID_COMMMON_FUNCTIONS_MAP);
         FUNCTIONS_MAP.putAll(SQUID_FUNCTIONS_MAP);
         FUNCTIONS_MAP.putAll(LOGIC_FUNCTIONS_MAP);
 
         ALIASED_FUNCTIONS_MAP.put("SqBiweight", "Biweight");
         ALIASED_FUNCTIONS_MAP.put("SqWtdAv", "WtdAv");
+        ALIASED_FUNCTIONS_MAP.put("TotalCPS", null);
 
     }
 
@@ -152,8 +156,10 @@ public abstract class Function
         String retVal = excelExpressionString;
         for (Entry<String, String> entry : ALIASED_FUNCTIONS_MAP.entrySet()) {
             if (retVal != null && retVal.matches(".*(?i)" + entry.getKey() + "(.*)")) {
-                // replace alias
-                retVal = retVal.replaceAll(entry.getKey(), entry.getValue());
+                // replace alias if not null
+                if (entry.getValue() != null) {
+                    retVal = retVal.replaceAll("(?i)" + entry.getKey(), entry.getValue());
+                }
             }
         }
 

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb206U238rad.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb206U238rad.java
@@ -34,14 +34,12 @@ public class Pb206U238rad extends Function {
     private static final long serialVersionUID = -2586058958550228458L;
 
     /**
-     * Provides the functionality of Squid's agePb76 by calling pbPbAge and
-     * returning "Age" and "AgeErr" and encoding the labels for each cell of the
-     * values array produced by eval.
+     * Provides the functionality of Squid2.5's pb206U238rad.
+     * Returns the radiogenic 206Pb/238U ratio for the
+     * specified age.
      *
      * @see
-     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/Pub.bas
-     * @see
-     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/UPb.bas
+     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/src/main/java/org/cirdles/ludwig/squid25/PbUTh_2.java
      */
     public Pb206U238rad() {
 
@@ -51,7 +49,7 @@ public class Pb206U238rad extends Function {
         rowCount = 1;
         colCount = 2;
         labelsForOutputValues = new String[][]{{"206Pb/238U"}};
-        labelsForInputValues = new String[]{"206Pb/238U Age"};
+        labelsForInputValues = new String[]{"per-spot expression for 206Pb/238U Age"};
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb46cor7.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb46cor7.java
@@ -38,24 +38,21 @@ public class Pb46cor7 extends Function {
     private static final long serialVersionUID = 8731067364281915559L;
 
     /**
-     * Provides the functionality of Squid's agePb76 by calling pbPbAge and
-     * returning "Age" and "AgeErr" and encoding the labels for each cell of the
-     * values array produced by eval.
+     * Provides the functionality of Squid2.5's pb46cor7. Returns 204Pb/206Pb
+     * required to force 206Pb/238U-207Pb/206Pb ages to concordance.
      *
      * @see
-     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/Pub.bas
-     * @see
-     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/UPb.bas
+     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/src/main/java/org/cirdles/ludwig/squid25/PbUTh_2.java
      */
     public Pb46cor7() {
 
-        name = "pb46cor7";
+        name = "Pb46cor7";
         argumentCount = 2;
         precedence = 4;
         rowCount = 1;
         colCount = 1;
         labelsForOutputValues = new String[][]{{"pb46cor7"}};
-        labelsForInputValues = new String[]{"207/206RatioAnd1\u03C3 abs", "207corr206Pb/238UAge"};
+        labelsForInputValues = new String[]{"207/206Ratio with 1\u03C3 abs", "per-spot expression for 207corr206Pb/238UAge"};
     }
 
     /**
@@ -79,7 +76,7 @@ public class Pb46cor7 extends Function {
         try {
             double[] pb207_206RatioAndUnct = convertObjectArrayToDoubles(childrenET.get(0).eval(shrimpFractions, task)[0]);
             double[] pb207corr206_238Age = convertObjectArrayToDoubles(childrenET.get(1).eval(shrimpFractions, task)[0]);
-            
+
             double sComm_64 = task.getTaskExpressionsEvaluationsPerSpotSet().get(DEFCOM_64).getValues()[0][0];
             double sComm_74 = task.getTaskExpressionsEvaluationsPerSpotSet().get(DEFCOM_74).getValues()[0][0];
 
@@ -110,7 +107,7 @@ public class Pb46cor7 extends Function {
     public String toStringMathML(List<ExpressionTreeInterface> childrenET) {
         String retVal
                 = "<mrow>"
-                + "<mi>Pb46cor7</mi>"
+                + "<mi>" + name + "</mi>"
                 + "<mfenced>";
 
         retVal += buildChildrenToMathML(childrenET);

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb46cor8.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb46cor8.java
@@ -37,24 +37,21 @@ public class Pb46cor8 extends Function {
     private static final long serialVersionUID = 6770836871819373387L;
 
     /**
-     * Provides the functionality of Squid's agePb76 by calling pbPbAge and
-     * returning "Age" and "AgeErr" and encoding the labels for each cell of the
-     * values array produced by eval.
+     * Provides the functionality of Squid2.5's pb46cor8. Returns 204Pb/206Pb
+     * required to force 206Pb/238U-208Pb/232Th ages to concordance.
      *
      * @see
-     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/Pub.bas
-     * @see
-     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/isoplot3Basic/UPb.bas
+     * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/src/main/java/org/cirdles/ludwig/squid25/PbUTh_2.java
      */
     public Pb46cor8() {
 
-        name = "pb46cor8";
+        name = "Pb46cor8";
         argumentCount = 3;
         precedence = 4;
         rowCount = 1;
         colCount = 1;
         labelsForOutputValues = new String[][]{{"pb46cor8"}};
-        labelsForInputValues = new String[]{"208/206RatioAnd1\u03C3 abs","232Th/238U","208corr206Pb/238UAge"};
+        labelsForInputValues = new String[]{"208/206RatioAnd1\u03C3 abs", "232Th/238U", "208corr206Pb/238UAge"};
     }
 
     /**
@@ -89,10 +86,10 @@ public class Pb46cor8 extends Function {
             double lambda238 = task.getTaskExpressionsEvaluationsPerSpotSet().get(LAMBDA238).getValues()[0][0];
 
             double[] pb46cor8 = org.cirdles.ludwig.squid25.PbUTh_2.pb46cor8(
-                    pb208_206RatioAndUnct[0], 
-                    thU[0], 
-                    sComm_64, 
-                    sComm_84, 
+                    pb208_206RatioAndUnct[0],
+                    thU[0],
+                    sComm_64,
+                    sComm_84,
                     pb208corr206_238Age[0], lambda232, lambda238);
             retVal = new Object[][]{{pb46cor8[0]}};
         } catch (ArithmeticException | IndexOutOfBoundsException | NullPointerException e) {
@@ -111,7 +108,7 @@ public class Pb46cor8 extends Function {
     public String toStringMathML(List<ExpressionTreeInterface> childrenET) {
         String retVal
                 = "<mrow>"
-                + "<mi>Pb46cor8</mi>"
+                + "<mi>" + name + "</mi>"
                 + "<mfenced>";
 
         retVal += buildChildrenToMathML(childrenET);

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb76.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb76.java
@@ -52,7 +52,7 @@ public class Pb76 extends Function {
         rowCount = 1;
         colCount = 2;
         labelsForOutputValues = new String[][]{{"207/206"}};
-        labelsForInputValues = new String[]{"207/206 Age"};
+        labelsForInputValues = new String[]{"per-spot expression for 207/206 Age"};
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb86radCor7per.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/Pb86radCor7per.java
@@ -39,7 +39,7 @@ public class Pb86radCor7per extends Function {
     private static final long serialVersionUID = -6404035232270915370L;
 
     /**
-     * Provides the functionality of Squid's Pb86radCor7per and returning
+     * Provides the functionality of Squid2.5's Pb86radCor7per and returning
      * radiogenic 208Pb/206Pb %err and encoding the labels for each cell of the
      * values array produced by eval.
      *
@@ -48,14 +48,14 @@ public class Pb86radCor7per extends Function {
      */
     public Pb86radCor7per() {
 
-        name = "pb86radCor7per";
+        name = "Pb86radCor7per";
         argumentCount = 5;
         precedence = 10;
         rowCount = 1;
         colCount = 1;
         labelsForOutputValues = new String[][]{{"pb86radCor7per"}};
         labelsForInputValues = new String[]{
-            "208/206RatioAndUnct", "207/206RatioAnd1\u03C3 abs", "Total206Pb/238U", "Total206Pb/238U%err", "207corr206Pb/238UAge"};
+            "208/206 Ratio with Unct", "207/206 Ratio with 1\u03C3 abs", "Total206Pb/238U", "Total206Pb/238U%err", "207corr206Pb/238UAge"};
     }
 
     /**
@@ -118,7 +118,7 @@ public class Pb86radCor7per extends Function {
     public String toStringMathML(List<ExpressionTreeInterface> childrenET) {
         String retVal
                 = "<mrow>"
-                + "<mi>Pb86radCor7per</mi>"
+                + "<mi>" + name + "</mi>"
                 + "<mfenced>";
 
         retVal += buildChildrenToMathML(childrenET);

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/RobReg.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/RobReg.java
@@ -32,7 +32,7 @@ public class RobReg extends Function {
     private static final long serialVersionUID = -198041668841495965L;
 
     /**
-     * Provides the functionality of Squid's robReg by calling robustReg2 and
+     * Provides the functionality of Squid2.5's robReg by calling robustReg2 and
      * returning "Slope", "SlopeErr", "Y-Intercept", "Y-IntErr" and encoding the
      * labels for each cell of the values array produced by eval.
      *
@@ -40,13 +40,13 @@ public class RobReg extends Function {
      * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/squid2.5Basic/Resistant.bas
      */
     public RobReg() {
-        name = "robReg";
+        name = "RobReg";
         argumentCount = 2;
         precedence = 4;
         rowCount = 1;
         colCount = 4;
         labelsForOutputValues = new String[][]{{"Slope", "SlopeErr", "Y-Intercept", "Y-IntErr"}};
-        labelsForInputValues = new String[]{"xNumbers", "yNumbers"};
+        labelsForInputValues = new String[]{"per-spot expression for 'X'", "per-spot expression for 'Y'"};
         summaryCalc = true;
         definition = "Provides the functionality of Squid's robReg by calling robustReg2 and\n"
                 + "   returning \"Slope\", \"SlopeErr\", \"Y-Intercept\", \"Y-IntErr\".";
@@ -93,7 +93,7 @@ public class RobReg extends Function {
     public String toStringMathML(List<ExpressionTreeInterface> childrenET) {
         String retVal
                 = "<mrow>"
-                + "<mi>RobReg</mi>"
+                + "<mi>" + name + "</mi>"
                 + "<mfenced>";
 
         retVal += buildChildrenToMathML(childrenET);

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/ShrimpSpeciesNodeFunction.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/ShrimpSpeciesNodeFunction.java
@@ -58,16 +58,21 @@ public class ShrimpSpeciesNodeFunction extends Function {
     @Override
     public Object[][] eval(List<ExpressionTreeInterface> childrenET, List<ShrimpFractionExpressionInterface> shrimpFractions, TaskInterface task) throws SquidException {
         //TODO refactor duplicate code
+        Object[][] results = new Object[][]{{0.0}};
+        
+        if (childrenET.get(0) instanceof ShrimpSpeciesNode){
         shrimpSpeciesNode = ((ShrimpSpeciesNode) childrenET.get(0));
         shrimpSpeciesNode.setMethodNameForShrimpFraction(methodNameForShrimpFraction);
 
-        Object[][] results = shrimpSpeciesNode.eval(shrimpFractions, task);
+        results = shrimpSpeciesNode.eval(shrimpFractions, task);
+        
+        // restore the node to anonymous
+        shrimpSpeciesNode.setMethodNameForShrimpFraction("");
+        }
         // added feb 2019 to handle BKG when forced
         if (results[0] == null){
             results = new Object[][]{{0.0}};
         }
-        // restore the node to anonymous
-        shrimpSpeciesNode.setMethodNameForShrimpFraction("");
         return results;
     }
 

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/SqBiweight.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/SqBiweight.java
@@ -34,10 +34,10 @@ public class SqBiweight extends Function {
     private static final long serialVersionUID = -1534611458354369530L;
 
     /**
-     * Provides the functionality of Squid's sqBiweight and biWt by calculating
+     * Provides the functionality of Squid2.5's sqBiweight and biWt by calculating
      * TukeysBiweight and returning mean, sigma, and 95% confidence and encoding
-     * the labels for each cell of the values array produced by eval.
-     * Squid3 prefers Biweight and supports both function names.
+     * the labels for each cell of the values array produced by eval. Squid3
+     * prefers Biweight and supports both function names.
      *
      * @see
      * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/squid2.5Basic/Resistant.bas
@@ -51,11 +51,10 @@ public class SqBiweight extends Function {
         rowCount = 1;
         colCount = 3;
         labelsForOutputValues = new String[][]{{"Biwt Mean", "Biwt Sigma", "\u00B195%conf"}};
-        labelsForInputValues = new String[]{"variableNumbers", "tuningConstant, default = 9"};
+        labelsForInputValues = new String[]{"per-spot expression with values and uncertainties", "tuningConstant, default = 9"};
         summaryCalc = true;
         definition = "Provides the functionality of Squid2.5's sqBiweight and biWt by calculating\n"
-                + DEF_TAB + "TukeysBiweight and returning mean, sigma, and 95% confidence.\n"
-                + DEF_TAB + "Squid3 recommends using 'Biweight' as an equivalent.";
+                + DEF_TAB + "TukeysBiweight and returning mean, sigma, and 95% confidence.";
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/SqBiweight.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/SqBiweight.java
@@ -37,6 +37,7 @@ public class SqBiweight extends Function {
      * Provides the functionality of Squid's sqBiweight and biWt by calculating
      * TukeysBiweight and returning mean, sigma, and 95% confidence and encoding
      * the labels for each cell of the values array produced by eval.
+     * Squid3 prefers Biweight and supports both function names.
      *
      * @see
      * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/squid2.5Basic/Resistant.bas
@@ -44,16 +45,17 @@ public class SqBiweight extends Function {
      * https://raw.githubusercontent.com/CIRDLES/LudwigLibrary/master/vbaCode/squid2.5Basic/StringUtils.bas
      */
     public SqBiweight() {
-        name = "sqBiweight";
+        name = "Biweight";
         argumentCount = 2;
         precedence = 4;
         rowCount = 1;
         colCount = 3;
         labelsForOutputValues = new String[][]{{"Biwt Mean", "Biwt Sigma", "\u00B195%conf"}};
-        labelsForInputValues = new String[]{"variableNumbers", "tuningConstant, use 9 as default"};
+        labelsForInputValues = new String[]{"variableNumbers", "tuningConstant, default = 9"};
         summaryCalc = true;
-        definition = "Provides the functionality of Squid's sqBiweight and biWt by calculating\n"
-                + "   TukeysBiweight and returning mean, sigma, and 95% confidence.";
+        definition = "Provides the functionality of Squid2.5's sqBiweight and biWt by calculating\n"
+                + DEF_TAB + "TukeysBiweight and returning mean, sigma, and 95% confidence.\n"
+                + DEF_TAB + "Squid3 recommends using 'Biweight' as an equivalent.";
     }
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/SqWtdAv.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/SqWtdAv.java
@@ -33,7 +33,7 @@ public class SqWtdAv extends Function {
     private static final long serialVersionUID = 2338965097822849460L;
 
     /**
-     * Provides the basic functionality of Squid's sqWtdAv by calculating
+     * Provides the basic functionality of Squid2.5's sqWtdAv by calculating
      * WeightedAverage and returning intMean, intSigmaMean, MSWD, probability,
      * intErr68, intMeanErr95 and encoding the labels for each cell of the
      * values array produced by eval.
@@ -44,12 +44,13 @@ public class SqWtdAv extends Function {
      * https://github.com/CIRDLES/LudwigLibrary/blob/master/vbaCode/isoplot3Basic/Means.bas
      */
     public SqWtdAv() {
-        name = "sqWtdAv";
+        name = "WtdAv";
         argumentCount = 1;
         precedence = 4;
         rowCount = 1;
         colCount = 6;
         labelsForOutputValues = new String[][]{{"intMean", "intSigmaMean", "MSWD", "probability", "intErr68", "intMeanErr95"}};
+        labelsForInputValues = new String[]{"per-spot expression with values and uncertainties"};
         summaryCalc = true;
         definition = "Provides the basic functionality of Squid's sqWtdAv by calculating\n"
                 + "   WeightedAverage and returning intMean, intSigmaMean, MSWD, probability,\n"

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/StdPb86radCor7per.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/functions/StdPb86radCor7per.java
@@ -37,7 +37,7 @@ public class StdPb86radCor7per extends Function {
     private static final long serialVersionUID = 3474777008380697077L;
 
     /**
-     * Provides the functionality of Squid's StdPb86radCor7per and returning
+     * Provides the functionality of Squid2.5's StdPb86radCor7per and returning
      * radiogenic 208Pb/206Pb %err and encoding the labels for each cell of the
      * values array produced by eval.
      *
@@ -46,14 +46,14 @@ public class StdPb86radCor7per extends Function {
      */
     public StdPb86radCor7per() {
 
-        name = "stdPb86radCor7per";
+        name = "StdPb86radCor7per";
         argumentCount = 4;
         precedence = 10;
         rowCount = 1;
         colCount = 1;
         labelsForOutputValues = new String[][]{{"stdPb86radCor7per"}};
         labelsForInputValues = new String[]{
-            "208/206RatioAnd1\u03C3 abs", "207/206RatioAnd1\u03C3 abs", "radPb86cor7", "pb46cor7"};
+            "208/206 Ratio with 1\u03C3 abs", "207/206 Ratio with 1\u03C3 abs", "per-spot expression for radPb86cor7", "per-spot expression for pb46cor7"};
     }
 
     /**
@@ -110,7 +110,7 @@ public class StdPb86radCor7per extends Function {
     public String toStringMathML(List<ExpressionTreeInterface> childrenET) {
         String retVal
                 = "<mrow>"
-                + "<mi>StdPb86radCor7per</mi>"
+                + "<mi>" + name + "</mi>"
                 + "<mfenced>";
 
         retVal += buildChildrenToMathML(childrenET);

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/parsing/ExpressionParser.java
@@ -315,8 +315,12 @@ public class ExpressionParser {
                             uncertaintyDirective);
                     retExpTree.copySettings(retExpTreeKnown);
 
-                } else if ((retExpTreeKnown instanceof ShrimpSpeciesNode)
-                        || (retExpTreeKnown instanceof SpotFieldNode)) {
+                } else if (retExpTreeKnown instanceof ShrimpSpeciesNode) {
+                    // make copy
+                    retExpTree = ShrimpSpeciesNode.buildShrimpSpeciesNode(
+                            ((ShrimpSpeciesNode) retExpTreeKnown).getSquidSpeciesModel(), "getTotalCps");
+
+                } else if (retExpTreeKnown instanceof SpotFieldNode) {
                     retExpTree = retExpTreeKnown;
                     retExpTree.setUncertaintyDirective(uncertaintyDirective);
 


### PR DESCRIPTION
fixes #304 by providing a default value of 9 for the tuning constant when Biweight is dropped and dragged in editor.

fixes #316 by providing 'common' and 'other' listings of Squid functions.

fixes #318 by changing project name to 'NEW PROJECT'.

fixes #321 .

Adds Isotopes listing to available expressions - shows TotalCPS of isotope for reference.

Adds Spot metadata fields to available expressions - 'BKG', Hours, PrimaryBeam, Qt1Y, and Qt1Z.

Various refactoring.