### PR TITLE
Various tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,8 @@ LudwigLibraryJavadoc/
 Schema/
 /Schema/
 squidApp/Squid3_Reports_v?.?.?
-squidApp/XSLTML
+squidApp/XSLTML/
+XSLTML/
 
 
 squidCore/expressionsImages

--- a/common.gradle
+++ b/common.gradle
@@ -6,7 +6,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 String mavenGroupId = 'org.cirdles'
-String mavenVersion = '1.1.9'
+String mavenVersion = '1.2.0'
 
 sourceCompatibility = '1.8'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'

--- a/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
@@ -1170,7 +1170,11 @@ public class SquidUIController implements Initializable {
     private void unknownsBySampleReportTableAction(ActionEvent event) throws IOException {
         File reportTableFile = squidProject.produceUnknownsBySampleForETReduxCSV(true);
         if (reportTableFile != null) {
-            BrowserControl.showURI(reportTableFile.getCanonicalPath());
+            SquidMessageDialog.showInfoDialog(
+                    "File saved as:\n\n"
+                    + showLongfilePath(reportTableFile.getCanonicalPath()),
+                    primaryStageWindow);
+//            BrowserControl.showURI(reportTableFile.getCanonicalPath());
         } else {
             SquidMessageDialog.showInfoDialog(
                     "There are no Unknowns chosen.\n\n",

--- a/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/SquidUIController.java
@@ -534,6 +534,7 @@ public class SquidUIController implements Initializable {
                     squidPersistentState.updateProjectListMRU(projectFile);
                     SquidUI.updateStageTitle(projectFile.getAbsolutePath());
                     buildProjectMenuMRU();
+                    launchProjectManager();
                 }
 
             } catch (IOException ex) {
@@ -628,6 +629,7 @@ public class SquidUIController implements Initializable {
                 }
             });
             SquidProject.setProjectChanged(false);
+            launchProjectManager();
         }
     }
 

--- a/squidApp/src/main/java/org/cirdles/squid/gui/utilities/fileUtilities/FileHandler.java
+++ b/squidApp/src/main/java/org/cirdles/squid/gui/utilities/fileUtilities/FileHandler.java
@@ -75,13 +75,16 @@ public class FileHandler {
         fileChooser.setSelectedExtensionFilter(new FileChooser.ExtensionFilter("Squid Project files", "*.squid"));
         File initDirectory = new File(squidPersistentState.getMRUProjectFolderPath());
         fileChooser.setInitialDirectory(initDirectory.exists() ? initDirectory : null);
-        fileChooser.setInitialFileName(squidProject.getProjectName().toUpperCase(Locale.ENGLISH) + ".squid");
+//        fileChooser.setInitialFileName(squidProject.getProjectName().toUpperCase(Locale.ENGLISH) + ".squid");
+        fileChooser.setInitialFileName(squidProject.getProjectName() + ".squid");
 
         File projectFileNew = fileChooser.showSaveDialog(ownerWindow);
 
         if (projectFileNew != null) {
             SquidProject.setProjectChanged(false);
             retVal = projectFileNew;
+            // capture squid project file name from file for project itself
+            squidProject.setProjectName(projectFileNew.getName().substring(0, projectFileNew.getName().lastIndexOf(".")));
             ProjectFileUtilities.serializeSquidProject(squidProject, projectFileNew.getCanonicalPath());
         }
 

--- a/squidCore/src/main/java/org/cirdles/squid/projects/SquidProject.java
+++ b/squidCore/src/main/java/org/cirdles/squid/projects/SquidProject.java
@@ -409,7 +409,7 @@ public final class SquidProject implements Serializable {
             ReportSettingsInterface reportSettings = new ReportSettings("UnknownsBySample", false, task);
             String[][] report = reportSettings.reportFractionsByNumberStyle(spotsBySampleNames, numberStyleIsNumeric);
             reportTableFile = prawnFileHandler.getReportsEngine().writeReportTableFiles(
-                    report, projectName + "_UnknownsBySampleReportTableForET_Redux.csv");
+                    report, projectName + "_UnknownsBySampleReportTableForET_ReduxAndTopsoil.csv");
         }
         return reportTableFile;
     }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/Task.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/Task.java
@@ -468,16 +468,19 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
 
     private void generateConstants() {
         Map<String, ExpressionTreeInterface> constants = BuiltInExpressionsFactory.generateConstants();
+        this.namedConstantsMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         namedConstantsMap.putAll(constants);
     }
 
     private void generateParameters() {
         Map<String, ExpressionTreeInterface> parameters = BuiltInExpressionsFactory.generateParameters();
+        this.namedParametersMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         namedParametersMap.putAll(parameters);
     }
 
     private void generateSpotLookupFields() {
         Map<String, ExpressionTreeInterface> spotLookupFields = BuiltInExpressionsFactory.generateSpotLookupFields();
+        this.namedSpotLookupFieldsMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         namedSpotLookupFieldsMap.putAll(spotLookupFields);
     }
 
@@ -1535,6 +1538,7 @@ public class Task implements TaskInterface, Serializable, XMLSerializerInterface
             namedExpressionsMap.put(entry.getKey(), entry.getValue());
         }
 
+        generateSpotLookupFields();
         for (Map.Entry<String, ExpressionTreeInterface> entry : namedSpotLookupFieldsMap.entrySet()) {
             namedExpressionsMap.put(entry.getKey(), entry.getValue());
         }

--- a/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/builtinExpressions/BuiltInExpressionsFactory.java
+++ b/squidCore/src/main/java/org/cirdles/squid/tasks/expressions/builtinExpressions/BuiltInExpressionsFactory.java
@@ -217,12 +217,24 @@ public abstract class BuiltInExpressionsFactory {
 
         ExpressionTreeInterface expHours = buildSpotNode("getHours");
         spotLookupFields.put(expHours.getName(), expHours);
+
         ExpressionTreeInterface expQt1Y = buildSpotNode("getQt1Y");
         spotLookupFields.put(expQt1Y.getName(), expQt1Y);
+
         ExpressionTreeInterface expQt1Z = buildSpotNode("getQt1Z");
         spotLookupFields.put(expQt1Z.getName(), expQt1Z);
+
         ExpressionTreeInterface expPrimaryBeam = buildSpotNode("getPrimaryBeam");
         spotLookupFields.put(expPrimaryBeam.getName(), expPrimaryBeam);
+
+        ExpressionTreeInterface expStageX = buildSpotNode("getStageX");
+        spotLookupFields.put(expStageX.getName(), expStageX);
+
+        ExpressionTreeInterface expStageY = buildSpotNode("getStageY");
+        spotLookupFields.put(expStageY.getName(), expStageY);
+
+        ExpressionTreeInterface expStageZ = buildSpotNode("getStageZ");
+        spotLookupFields.put(expStageZ.getName(), expStageZ);
 
         // special case for BKG to provide for lookup in built-in expressions returning ZERO if no BKG
         ShrimpSpeciesNode spm


### PR DESCRIPTION
fixes #324, adds Stage X, Stage Y and Stage Z coordinates to the spot metadata expressions
fixes #317, #319, by tying Squid project name and project name together and eliminating the auto-open of csv files.