### PR TITLE
Schema validation and spot target attribute for Squid report tables.

### DIFF
--- a/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
+++ b/squidCore/src/main/java/org/cirdles/squid/constants/Squid3Constants.java
@@ -112,6 +112,26 @@ public final class Squid3Constants {
     public static final String URL_STRING_FOR_SQUIDTASK_EXPRESSION_XML_SCHEMA_LOCAL
             = SCHEMA_FOLDER.getAbsolutePath() + File.separator + "SquidTask_ExpressionXMLSchema.xsd";
 
+    /**
+     *
+     */
+    public static final String XML_HEADER_FOR_SQUIDREPORTTABLE_FILES_USING_LOCAL_SCHEMA
+            = "<?xml version=\"1.0\"?>\n"
+            + "<!-- SQUIDREPORTTABLE_DATA_FILE -->\n"
+            + "<SquidReportTable xmlns=\"https://raw.githubusercontent.com\"\n"
+            + "            xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n"
+            + "            xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+            + "            xsi:schemaLocation=\"https://raw.githubusercontent.com\n"
+            + "                                ../schema/SquidReportTable.xsd\">";
+
+    /**
+     *
+     */
+    public static final String URL_STRING_FOR_SQUIDREPORTTABLE_XML_SCHEMA_LOCAL
+            = SCHEMA_FOLDER.getAbsolutePath() + File.separator + "SquidReportTable.xsd";
+    /**
+     *
+     */
     private static final String[] DEFAULT_RATIOS_LIST_FOR_10_SPECIES = new String[]{
         "204/206", "207/206", "208/206", "238/196", "206/238", "254/238", "248/254", "206/270", "270/254", "206/254", "238/206"};
 
@@ -316,7 +336,8 @@ public final class Squid3Constants {
 
     public static enum SpotTypes {
         REFERENCE_MATERIAL("REFERENCE MATERIALS"),
-        UNKNOWN("UNKNOWNS");
+        UNKNOWN("UNKNOWNS"),
+        NONE("NONE");
 
         private String plotType;
 

--- a/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportCategories/SquidReportCategory.java
+++ b/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportCategories/SquidReportCategory.java
@@ -20,6 +20,14 @@ import org.cirdles.squid.squidReports.squidReportColumns.SquidReportColumn;
 import org.cirdles.squid.squidReports.squidReportColumns.SquidReportColumnInterface;
 import org.cirdles.squid.squidReports.squidReportColumns.SquidReportColumnXMLConverter;
 
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,6 +44,13 @@ import org.cirdles.squid.utilities.IntuitiveStringComparator;
 /**
  * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
  */
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlType(name = "reportCategory", propOrder = {
+    "displayName",
+    "categoryColumns",
+    "visible"
+})
 public class SquidReportCategory implements Serializable, SquidReportCategoryInterface {
 
     private static final long serialVersionUID = 8741573410884399160L;
@@ -87,8 +102,14 @@ public class SquidReportCategory implements Serializable, SquidReportCategoryInt
     }
 
     // Fields
+    @XmlElement(name = "displayName", required = true)
     private String displayName;
+
+    @XmlElementWrapper(name = "categoryColumns")
+    @XmlElement(name = "SquidReportColumn", required = true)
     private LinkedList<SquidReportColumnInterface> categoryColumns;
+
+    @XmlElement(name = "visible")
     private boolean visible;
 
     private SquidReportCategory() {
@@ -207,5 +228,17 @@ public class SquidReportCategory implements Serializable, SquidReportCategoryInt
     @Override
     public int hashCode() {
         return Objects.hash(getDisplayName(), getCategoryColumns(), isVisible());
+    }
+
+    // https://stackoverflow.com/questions/4101718/jaxb-cant-handle-interfaces
+    public static class Adapter extends XmlAdapter<SquidReportCategory, SquidReportCategoryInterface>{
+        @Override
+         public SquidReportCategoryInterface unmarshal(SquidReportCategory cat){
+            return cat;
+        }
+        @Override
+        public SquidReportCategory marshal(SquidReportCategoryInterface cat){
+            return (SquidReportCategory) cat;
+        }
     }
 }

--- a/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportCategories/SquidReportCategoryInterface.java
+++ b/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportCategories/SquidReportCategoryInterface.java
@@ -17,6 +17,7 @@ package org.cirdles.squid.squidReports.squidReportCategories;
 
 import static java.nio.file.Paths.get;
 import java.util.LinkedList;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.cirdles.squid.squidReports.squidReportColumns.SquidReportColumn;
 import org.cirdles.squid.squidReports.squidReportColumns.SquidReportColumnInterface;
 import org.cirdles.squid.utilities.xmlSerialization.XMLSerializerInterface;
@@ -25,6 +26,8 @@ import org.cirdles.squid.utilities.xmlSerialization.XMLSerializerInterface;
  *
  * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
  */
+
+@XmlJavaTypeAdapter(SquidReportCategory.Adapter.class)
 public interface SquidReportCategoryInterface extends XMLSerializerInterface {
 
     /**

--- a/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportColumns/SquidReportColumn.java
+++ b/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportColumns/SquidReportColumn.java
@@ -32,6 +32,12 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
 import static org.cirdles.squid.constants.Squid3Constants.ABS_UNCERTAINTY_DIRECTIVE;
 import static org.cirdles.squid.constants.Squid3Constants.PCT_UNCERTAINTY_DIRECTIVE;
 import static org.cirdles.squid.squidReports.squidReportColumns.SquidReportColumnInterface.formatBigDecimalForPublicationSigDigMode;
@@ -42,6 +48,18 @@ import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpr
 /**
  * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
  */
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlType(name = "", propOrder = {
+    "expressionName",
+    "units",
+    "uncertaintyColumn",
+    "amUncertaintyColumn",
+    "uncertaintyDirective",
+    "countOfSignificantDigits",
+    "visible",
+    "footnoteSpec"
+})
 public class SquidReportColumn implements Serializable, SquidReportColumnInterface {
 
     private static final long serialVersionUID = -4256285353332428810L;
@@ -52,18 +70,31 @@ public class SquidReportColumn implements Serializable, SquidReportColumnInterfa
     // provides for multi-row column headers
     private transient String[] columnHeaders;
 
+    @XmlElement(name = "expressionName", required = true)
     private String expressionName;
+
     // used to calculate shiftPointRightCount = Squid3Constants.getUnitConversionMoveCount(units)
+    @XmlElement(name = "units", required = false)
     private String units;
 
     // optional uncertainty column
+    @XmlElement(name = "uncertaintyColumn", required = false)
     private SquidReportColumnInterface uncertaintyColumn;
+
+    @XmlElement(name = "amUncertaintyColumn", required = true)
     private boolean amUncertaintyColumn;
+
     // 1 sigma abs or pct if uncertainty column
+    @XmlElement(name = "uncertaintyDirective", required = false)
     private String uncertaintyDirective;
 
+    @XmlElement(name = "countOfSignificantDigits", required = true)
     private int countOfSignificantDigits;
+
+    @XmlElement(name = "visible", required = true)
     private boolean visible;
+
+    @XmlElement(name = "footnoteSpec", required = false)
     private String footnoteSpec;
 
     private SquidReportColumn() {
@@ -113,7 +144,7 @@ public class SquidReportColumn implements Serializable, SquidReportColumnInterfa
     @Override
     public void initReportColumn(TaskInterface task) {
         String expressionNameCustom = expressionName;
-        
+
         // extract properties of expTree
         expTree = task.findNamedExpression(expressionName);
         if (expTree instanceof SpotFieldNode) {
@@ -467,5 +498,17 @@ public class SquidReportColumn implements Serializable, SquidReportColumnInterfa
         result = 31 * result + Arrays.hashCode(getColumnHeaders());
         return result;
 
+    }
+
+    //https://stackoverflow.com/questions/4101718/jaxb-cant-handle-interfaces
+    public static class Adapter extends XmlAdapter<SquidReportColumn, SquidReportColumnInterface>{
+        @Override
+        public SquidReportColumnInterface unmarshal(SquidReportColumn col){
+            return col;
+        }
+        @Override
+        public SquidReportColumn marshal(SquidReportColumnInterface col){
+            return (SquidReportColumn)col;
+        }
     }
 }

--- a/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportColumns/SquidReportColumnInterface.java
+++ b/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportColumns/SquidReportColumnInterface.java
@@ -18,6 +18,7 @@ package org.cirdles.squid.squidReports.squidReportColumns;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.cirdles.squid.shrimp.ShrimpFractionExpressionInterface;
 import org.cirdles.squid.tasks.TaskInterface;
 import org.cirdles.squid.tasks.expressions.expressionTrees.ExpressionTreeInterface;
@@ -27,6 +28,8 @@ import org.cirdles.squid.utilities.xmlSerialization.XMLSerializerInterface;
  *
  * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
  */
+
+@XmlJavaTypeAdapter(SquidReportColumn.Adapter.class)
 public interface SquidReportColumnInterface extends XMLSerializerInterface {
 
     public void initReportColumn(TaskInterface task);

--- a/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTable.java
+++ b/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTable.java
@@ -36,12 +36,31 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
 import static org.cirdles.squid.squidReports.squidReportCategories.SquidReportCategory.createReportCategory;
 import static org.cirdles.squid.tasks.expressions.builtinExpressions.BuiltInExpressionsDataDictionary.*;
+import static org.cirdles.squid.constants.Squid3Constants.SpotTypes;
+import static org.cirdles.squid.constants.Squid3Constants.XML_HEADER_FOR_SQUIDREPORTTABLE_FILES_USING_LOCAL_SCHEMA;
 
 /**
  * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
  */
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlType(name = "", propOrder = {
+    "reportTableName",
+    "reportCategories",
+    "reportSpotTarget",
+    "isDefault",
+    "version"
+})
+@XmlRootElement(name = "SquidReportTable")
 public class SquidReportTable implements Serializable, SquidReportTableInterface {
 
     private static final long serialVersionUID = 1685572683987304408L;
@@ -53,10 +72,20 @@ public class SquidReportTable implements Serializable, SquidReportTableInterface
     public final static int DEFAULT_COUNT_OF_SIGNIFICANT_DIGITS = 15;
 
     // Fields
+    @XmlElement(name = "reportTableName", required = true)
     private String reportTableName;
+
+    @XmlElementWrapper(name = "reportCategories")
+    @XmlElement(name = "reportCategory", required = true)
     private LinkedList<SquidReportCategoryInterface> reportCategories;
+
+    @XmlElement(name = "reportSpotTarget", required = false) // Backwards compatibility with report tables prior to ...
+    private SpotTypes reportSpotTarget;
+
+    @XmlElement(name = "isDefault", required = true)
     private boolean isDefault;
 
+    @XmlElement(name = "version", required = false)
     private int version;
 
     private SquidReportTable() {
@@ -188,7 +217,7 @@ public class SquidReportTable implements Serializable, SquidReportTableInterface
 //            if ((!expTree.isSquidSwitchSCSummaryCalculation())
 //                    && (expTree.isSquidSwitchSTReferenceMaterialCalculation())) {
 //                custom_RM.getCategoryColumns().add(SquidReportColumn.createSquidReportColumn(expTree.getName()));
-//            }    
+//            }
 //        }
 //        reportCategoriesRefMat.add(custom_RM);
         return reportCategoriesRefMat;
@@ -351,6 +380,22 @@ public class SquidReportTable implements Serializable, SquidReportTableInterface
     public void setReportCategories(LinkedList<SquidReportCategoryInterface> reportCategories) {
         this.reportCategories = reportCategories;
     }
+    
+    /**
+     * @return the reportSpotTarget
+     */
+    @Override
+    public SpotTypes getReportSpotTarget(){
+        return this.reportSpotTarget;
+    }
+    
+    /**
+     * @param reportSpotTarget the reportSpotTarget to set
+     */
+    @Override
+    public void setReportSpotTarget(SpotTypes reportSpotTarget){
+        this.reportSpotTarget = reportSpotTarget;
+    }
 
     public void setIsDefault(boolean isDefault) {
         this.isDefault = isDefault;
@@ -358,6 +403,14 @@ public class SquidReportTable implements Serializable, SquidReportTableInterface
 
     public boolean isDefault() {
         return isDefault;
+    }
+
+    @Override
+    public String customizeXML(String xml) {
+        String xmlR = xml;
+        xmlR = xmlR.replaceFirst("<SquidReportTable>",
+                XML_HEADER_FOR_SQUIDREPORTTABLE_FILES_USING_LOCAL_SCHEMA);
+        return xmlR;
     }
 
     @Override

--- a/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTableInterface.java
+++ b/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTableInterface.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import static org.cirdles.squid.constants.Squid3Constants.SpotTypes;
 import org.cirdles.squid.shrimp.ShrimpFractionExpressionInterface;
 import org.cirdles.squid.squidReports.squidReportCategories.SquidReportCategoryInterface;
 import org.cirdles.squid.squidReports.squidReportColumns.SquidReportColumnInterface;
@@ -139,6 +140,16 @@ public interface SquidReportTableInterface extends XMLSerializerInterface {
      * @param reportCategories the reportCategories to set
      */
     public void setReportCategories(LinkedList<SquidReportCategoryInterface> reportCategories);
+    
+    /**
+     * @return the reportSpotTarget
+     */
+    public SpotTypes getReportSpotTarget();
+    
+    /**
+     * @param reportSpotTarget the reportSpotTarget to set
+     */
+    public void setReportSpotTarget(SpotTypes reportSpotTarget);
 
     public void setIsDefault(boolean isDefault);
 

--- a/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTableXMLConverter.java
+++ b/squidCore/src/main/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTableXMLConverter.java
@@ -9,6 +9,8 @@ import org.cirdles.squid.squidReports.squidReportCategories.SquidReportCategory;
 import org.cirdles.squid.squidReports.squidReportCategories.SquidReportCategoryInterface;
 import org.cirdles.squid.tasks.Task;
 
+import static org.cirdles.squid.constants.Squid3Constants.SpotTypes;
+
 import java.util.LinkedList;
 
 public class SquidReportTableXMLConverter implements Converter {
@@ -28,9 +30,21 @@ public class SquidReportTableXMLConverter implements Converter {
             writer.endNode();
         }
         writer.endNode();
+        
+
+        if (table.getReportSpotTarget() == null) {  // Backwards compatibility with report tables prior to ...
+            table.setReportSpotTarget(SpotTypes.NONE);
+        }
+        writer.startNode("reportSpotTarget");
+        writer.setValue(table.getReportSpotTarget().name());
+        writer.endNode();
 
         writer.startNode("isDefault");
         writer.setValue(Boolean.toString(table.isDefault()));
+        writer.endNode();
+        
+        writer.startNode("version");
+        writer.setValue(Integer.toString(table.getVersion()));
         writer.endNode();
     }
 
@@ -52,8 +66,19 @@ public class SquidReportTableXMLConverter implements Converter {
         }
         reader.moveUp();
 
+        // Backwards compatibility with report tables prior to ...
         reader.moveDown();
+        if(reader.getNodeName().equals("reportSpotTarget")) {
+            table.setReportSpotTarget(SpotTypes.valueOf(reader.getValue()));
+            reader.moveUp();
+            reader.moveDown();
+        }
+
         table.setIsDefault(Boolean.parseBoolean(reader.getValue()));
+        reader.moveUp();
+
+        reader.moveDown();
+        table.setVersion(Integer.parseInt(reader.getValue()));
         reader.moveUp();
 
         return table;

--- a/squidCore/src/main/java/org/cirdles/squid/utilities/fileUtilities/CalamariFileUtilities.java
+++ b/squidCore/src/main/java/org/cirdles/squid/utilities/fileUtilities/CalamariFileUtilities.java
@@ -318,6 +318,15 @@ public class CalamariFileUtilities {
                 } else {
                     //System.out.println("Failed to add SquidTask_ExpressionXMLSchema.xsd.");
                 }
+                
+                File squidReportTableSchemaResource = prawnFileResourceExtractor.extractResourceAsFile("schema/SquidReportTable.xsd");
+                File squidReportTableSchema = new File(SCHEMA_FOLDER.getCanonicalPath() + File.separator + "SquidReportTable.xsd");
+
+                if (squidReportTableSchemaResource.renameTo(squidReportTableSchema)) {
+                    //System.out.println("SquidReportTable.xsd added.");
+                } else {
+                    //System.out.println("Failed to add SquidReportTable.xsd.");
+                }
             }
         } catch (IOException iOException) {
         }

--- a/squidCore/src/main/resources/org/cirdles/squid/schema/SquidReportTable.xsd
+++ b/squidCore/src/main/resources/org/cirdles/squid/schema/SquidReportTable.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           attributeFormDefault="unqualified" 
+           elementFormDefault="qualified" 
+           targetNamespace="https://raw.githubusercontent.com"
+           xmlns="https://raw.githubusercontent.com">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This schema defines the contents of a Squid Report Table.
+
+            Copyright 2019-2020 CIRDLES.org
+
+            Licensed under the Apache License, Version 2.0 (the "License");
+            you may not use this file except in compliance with the License.
+            You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+            Unless required by applicable law or agreed to in writing, software
+            distributed under the License is distributed on an "AS IS" BASIS,
+            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            See the License for the specific language governing permissions and
+            limitations under the License.
+
+            Author: James F. Bowring[smtp:bowring@gmail.com]
+            Created: September.2020
+            
+        </xs:documentation>
+    </xs:annotation> 
+
+  <xs:element name="SquidReportTable">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="reportTableName" type="xs:string"/>
+        <xs:element name="reportCategories" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="SquidReportCategory" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="displayName" type="xs:string"/>
+                    <xs:element name="categoryColumns" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="SquidReportColumn" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="expressionName" type="xs:string"/>
+                                <xs:element name="units" type="xs:string" minOccurs="0"/>
+                                <xs:element name="uncertaintyColumn" minOccurs="0"/>
+                                <xs:element name="amUncertaintyColumn" type="xs:boolean"/>
+                                <xs:element name="uncertaintyDirective" type="xs:string" minOccurs="0"/>
+                                <xs:element name="countOfSignificantDigits" type="xs:int"/>
+                                <xs:element name="visible" type="xs:boolean"/>
+                                <xs:element name="footnoteSpec" type="xs:string" minOccurs="0"/>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="visible" type="xs:boolean"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="reportSpotTarget" type="spotTypes" minOccurs="0"/>
+        <xs:element name="isDefault" type="xs:boolean"/>
+        <xs:element name="version" type="xs:int"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="spotTypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="REFERENCE_MATERIAL"/>
+      <xs:enumeration value="UNKNOWN"/>
+      <xs:enumeration value="NONE"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/squidCore/src/test/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTableXSDValidationTest.java
+++ b/squidCore/src/test/java/org/cirdles/squid/squidReports/squidReportTables/SquidReportTableXSDValidationTest.java
@@ -1,0 +1,42 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.cirdles.squid.squidReports.squidReportTables;
+
+import java.io.File;
+import java.util.Arrays;
+import javax.xml.XMLConstants;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import org.cirdles.commons.util.ResourceExtractor;
+import org.cirdles.squid.Squid;
+import org.cirdles.squid.constants.Squid3Constants;
+import org.cirdles.squid.utilities.fileUtilities.FileValidator;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Noah
+ */
+public class SquidReportTableXSDValidationTest {
+    @Test
+    public void defaultRefMatTableTest(){
+        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        ResourceExtractor squidReportTableExtractor = new ResourceExtractor(SquidReportTableXSDValidationTest.class);
+        boolean validates = false;
+        try {
+            final File squidReportTableSchema = squidReportTableExtractor.extractResourceAsFile("SquidReportTable.xsd");
+            final Schema schema = sf.newSchema(squidReportTableSchema);
+            final File defaultRefMatXML = squidReportTableExtractor.extractResourceAsFile("defaultRefMat.xml");
+            validates = FileValidator.validateFileIsXMLSerializedEntity(defaultRefMatXML, schema);
+        } catch (SAXException e) {
+        }
+        finally {
+            assertTrue(validates);
+        }
+    }
+}

--- a/squidCore/src/test/resources/org/cirdles/squid/squidReports/squidReportTables/SquidReportTable.xsd
+++ b/squidCore/src/test/resources/org/cirdles/squid/squidReports/squidReportTables/SquidReportTable.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+           attributeFormDefault="unqualified" 
+           elementFormDefault="qualified" 
+           targetNamespace="https://raw.githubusercontent.com"
+           xmlns="https://raw.githubusercontent.com">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This schema defines the contents of a Squid Report Table.
+
+            Copyright 2019-2020 CIRDLES.org
+
+            Licensed under the Apache License, Version 2.0 (the "License");
+            you may not use this file except in compliance with the License.
+            You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+            Unless required by applicable law or agreed to in writing, software
+            distributed under the License is distributed on an "AS IS" BASIS,
+            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            See the License for the specific language governing permissions and
+            limitations under the License.
+
+            Author: James F. Bowring[smtp:bowring@gmail.com]
+            Created: September.2020
+            
+        </xs:documentation>
+    </xs:annotation> 
+
+  <xs:element name="SquidReportTable">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="reportTableName" type="xs:string"/>
+        <xs:element name="reportCategories" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="SquidReportCategory" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="displayName" type="xs:string"/>
+                    <xs:element name="categoryColumns" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="SquidReportColumn" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="expressionName" type="xs:string"/>
+                                <xs:element name="units" type="xs:string" minOccurs="0"/>
+                                <xs:element name="uncertaintyColumn" minOccurs="0"/>
+                                <xs:element name="amUncertaintyColumn" type="xs:boolean"/>
+                                <xs:element name="uncertaintyDirective" type="xs:string" minOccurs="0"/>
+                                <xs:element name="countOfSignificantDigits" type="xs:int"/>
+                                <xs:element name="visible" type="xs:boolean"/>
+                                <xs:element name="footnoteSpec" type="xs:string" minOccurs="0"/>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="visible" type="xs:boolean"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="reportSpotTarget" type="spotTypes" minOccurs="0"/>
+        <xs:element name="isDefault" type="xs:boolean"/>
+        <xs:element name="version" type="xs:int"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="spotTypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="REFERENCE_MATERIAL"/>
+      <xs:enumeration value="UNKNOWN"/>
+      <xs:enumeration value="NONE"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>
+


### PR DESCRIPTION
Here, I insert annotations above the attributes of SquidReportTable, SquidReportCategory, and SquidReportColumn to generate a schema which can be used to validate imported report table .xml files. I also add a feature which automatically switches the ReportSettingsController to the targeted spots of the imported table's expressions.